### PR TITLE
fix(dedupe): expire content-derived inbound keys after 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ publish workflow extracts the matching section as the release notes (see
 
 ## [Unreleased]
 
+### Fixed
+
+- **Repeated identical slash commands no longer disappear for 30 minutes
+  (issue #114).** Live Cliq Message Handlers can forward `message` as a bare
+  string with no `message.id` or `message.time`, so the plugin derives a
+  content-based synthetic id. That id now uses a 60-second dedupe TTL, matching
+  Cliq's practical retry window: a short redelivery (including caption-less
+  files) is still suppressed, while a deliberate later `/status`, `/new`, or
+  other identical command starts a new agent turn. Real message ids and
+  plugin-owned event ids retain the 30-minute replay-protection TTL.
+
 ### Added
 
 - **Public HTTPS webhook preflight (issue #96).** A reusable, non-dispatching

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ DM the bot → it answers. To also reply to channel **@mentions** and stream liv
 - **🔐 OAuth 2.0** — `client_credentials` for DMs; a user-context **refresh token** for channel posts / message edits. Works on any Zoho [data center](#data-centers).
 - **🛡️ DM security** — `allowlist` / `pairing` / `open` / `disabled` policies with an approval flow.
 - **🧩 Per-channel policy** — Group admission + per-channel `requireMention`, tool policy, and per-sender tool overrides.
-- **🔁 Reliability** — Durable-before-ack ingest, de-dup on redelivery, bot-loop / self-message protection, outbound retry with error classification (parses the v3 `{"message":"…"}` error envelope).
+- **🔁 Reliability** — Durable-before-ack ingest, de-dup on redelivery, bot-loop / self-message protection, outbound retry with error classification (parses the v3 `{"message":"…"}` error envelope). Real Cliq message ids retain 30-minute replay protection; content-derived ids used when the Message Handler supplies no `message.id` expire after 60 seconds, so retry redeliveries are suppressed without swallowing a deliberate repeated command such as `/status`.
 - **🔒 Hardened webhook** — Constant-time secret compare, single-header auth, failed-auth rate limiting.
 - **🩺 Operations** — `openclaw status` / `channels` health probe, `openclaw directory` lookup, plugin doctor, interactive setup wizard, SecretRef credentials, security audit, session binding, multi-account, lifecycle hooks.
 
@@ -444,6 +444,10 @@ return response;
 > `handler` value: `"message"` in the **Message Handler** (DMs) and `"mention"`
 > in the **Mention Handler** (channel/group @mentions). Group vs DM is detected
 > automatically from the forwarded `chat` object, so no extra mapping is needed.
+> In live Cliq Message Handlers, `message` may be a bare string with no
+> `message.id` or `message.time`. The plugin handles that shape without changing
+> this script: content-derived dedupe identities expire after 60 seconds, so a
+> short redelivery is suppressed but a later identical command is processed.
 
 > **Do not use `parameters: payload.toString()`.** In Deluge, `invokeUrl`'s
 > `parameters:` key serializes the value as form-urlencoded data

--- a/docs/learnings/110-synthetic-message-id-must-include-text-or-distinct-dms-dedupe.md
+++ b/docs/learnings/110-synthetic-message-id-must-include-text-or-distinct-dms-dedupe.md
@@ -30,12 +30,12 @@ id). The `[cliq] inbound … skipped as duplicate` line only logs under
 output — indistinguishable from "never reached the gateway".
 
 **Fix:** include the message `text` in the synthetic-id hash. Distinct messages
-(`hallo` ≠ `/model` ≠ `/models`) now get distinct ids and are all processed; a
+(`hallo` ≠ `/model` ≠ `/models`) get distinct ids and are all processed; a
 genuine Cliq redelivery of the *same* message carries identical text → identical
-id → still correctly deduped. (A user re-sending the exact same text within the
-TTL is still deduped — acceptable; the proper long-term fix is for the Deluge
-message handler to forward a real `message.id` or `message.time`, which would
-also distinguish legitimate identical re-sends from redeliveries.)
+id → still correctly deduped. Identical content remains indistinguishable from a
+redelivery, so `syn:` and composite keys use the short redelivery-window TTL;
+real message ids retain the longer replay-protection TTL. The Deluge handler
+cannot supply a real `message.id` or `message.time` for bare-string messages.
 
 Takeaway: any content-hash used as a message identity key for the bot Message
 handler MUST include the message text — sender+chat alone is not unique per

--- a/src/dedupe.test.ts
+++ b/src/dedupe.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   buildCliqDedupeKey,
   claimCliqMessage,
@@ -6,7 +6,7 @@ import {
   releaseCliqMessage,
   resetCliqDedupeForTest,
 } from "./dedupe.js";
-import type { ParsedCliqInbound } from "./inbound.js";
+import { parseCliqWebhookPayload, type ParsedCliqInbound } from "./inbound.js";
 
 function parsed(overrides: Partial<ParsedCliqInbound> = {}): ParsedCliqInbound {
   return {
@@ -200,5 +200,106 @@ describe("claimCliqMessage / commit / release", () => {
     expect(c1!.kind).toBe("claimed");
     expect(c2!.kind).toBe("claimed");
     expect(c1!.key).not.toBe(c2!.key);
+  });
+});
+
+describe("dedupe TTL by key kind (issue #114)", () => {
+  beforeEach(() => {
+    resetCliqDedupeForTest();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetCliqDedupeForTest();
+  });
+
+  const REDELIVERY_WINDOW_MS = 20_000;
+  const PAST_CONTENT_TTL_MS = 5 * 60 * 1000;
+
+  it("re-claims an identical slash command sent again well after the redelivery window (synthetic id)", async () => {
+    const payload = {
+      handler: "message",
+      message: "/status",
+      user: { id: "fake-user", name: "Test User" },
+      chat: { id: "fake-chat", type: "dm" },
+    };
+    const command = parseCliqWebhookPayload(payload);
+    expect(command).not.toBeNull();
+    expect(command!.messageId).toMatch(/^syn:/);
+
+    const sameCommandAgain = parseCliqWebhookPayload(payload);
+    expect(sameCommandAgain).not.toBeNull();
+    expect(sameCommandAgain!.messageId).toBe(command!.messageId);
+
+    const first = await claimCliqMessage(command!, account);
+    expect(first!.kind).toBe("claimed");
+    await commitCliqMessage(first!.key);
+
+    vi.advanceTimersByTime(REDELIVERY_WINDOW_MS);
+    const redelivery = await claimCliqMessage(sameCommandAgain!, account);
+    expect(redelivery!.kind).toBe("duplicate");
+
+    vi.advanceTimersByTime(PAST_CONTENT_TTL_MS);
+    const resend = await claimCliqMessage(sameCommandAgain!, account);
+    expect(resend!.kind).toBe("claimed");
+  });
+
+  it("re-claims an identical slash command sent again well after the redelivery window (composite key)", async () => {
+    const command = parsed({ messageId: "", text: "/new" });
+
+    const first = await claimCliqMessage(command, account);
+    expect(first!.kind).toBe("claimed");
+    expect(first!.key).toBe("cliq:default:cmp:u1:CT_dm_chat-B1:/new");
+    await commitCliqMessage(first!.key);
+
+    vi.advanceTimersByTime(REDELIVERY_WINDOW_MS);
+    const redelivery = await claimCliqMessage(command, account);
+    expect(redelivery!.kind).toBe("duplicate");
+
+    vi.advanceTimersByTime(PAST_CONTENT_TTL_MS);
+    const resend = await claimCliqMessage(command, account);
+    expect(resend!.kind).toBe("claimed");
+  });
+
+  it("keeps deduping a redelivered caption-less file message inside the redelivery window (issue #84)", async () => {
+    const upload = parsed({
+      messageId: "",
+      text: "",
+      attachments: [{ fileName: "quarterly.png" }],
+    });
+
+    const first = await claimCliqMessage(upload, account);
+    expect(first!.kind).toBe("claimed");
+    await commitCliqMessage(first!.key);
+
+    vi.advanceTimersByTime(REDELIVERY_WINDOW_MS);
+    const redelivery = await claimCliqMessage(upload, account);
+    expect(redelivery!.kind).toBe("duplicate");
+  });
+
+  it("keeps the long TTL for a real message id, which is unique per message", async () => {
+    const real = parsed({ messageId: "real-msg-1" });
+
+    const first = await claimCliqMessage(real, account);
+    expect(first!.kind).toBe("claimed");
+    await commitCliqMessage(first!.key);
+
+    vi.advanceTimersByTime(PAST_CONTENT_TTL_MS);
+    const redelivery = await claimCliqMessage(real, account);
+    expect(redelivery!.kind).toBe("duplicate");
+  });
+
+  it("keeps the long TTL for the synthetic welcome id so a subscriber is never greeted twice", async () => {
+    const welcome = parsed({ messageId: "welcome:u1", text: "", attachments: [] });
+
+    const first = await claimCliqMessage(welcome, account);
+    expect(first!.kind).toBe("claimed");
+    await commitCliqMessage(first!.key);
+
+    vi.advanceTimersByTime(PAST_CONTENT_TTL_MS);
+    const redelivery = await claimCliqMessage(welcome, account);
+    expect(redelivery!.kind).toBe("duplicate");
   });
 });

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -24,32 +24,42 @@
  *   - On retryable failure → `releaseCliqMessage` so the next redelivery can
  *     re-enter the pipeline (the slot is not recorded).
  *
- * The dedupe key prefers the Cliq `message.id`. When the Deluge handler
- * omits it (rare), we fall back to a composite of sender + chat + text —
- * which means two *distinct* identical messages from the same sender in the
- * same chat within the TTL would be wrongly deduped. This is an acceptable
- * tradeoff because the canonical Deluge handler always sets `message.id`.
+ * The dedupe key prefers the Cliq `message.id`. Content-derived fallback
+ * identities are retained only for Cliq's short practical redelivery window,
+ * while real message ids use the longer replay-protection TTL.
  */
 
 import { createClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import type { ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import type { ParsedCliqInbound } from "./inbound.js";
 
-/** TTL for the in-memory dedupe cache. Matches Cliq's practical redelivery window. */
+/** TTL for real Cliq message ids and plugin-owned event ids. */
 const CLIQ_DEDUPE_TTL_MS = 30 * 60 * 1000;
-/** Max entries retained in the in-memory dedupe cache. */
+const CLIQ_CONTENT_DEDUPE_TTL_MS = 60 * 1000;
+/** Max entries retained across each in-memory dedupe cache. */
 const CLIQ_DEDUPE_MEMORY_MAX_SIZE = 5000;
 
-let dedupe: ClaimableDedupe | null = null;
+let longLivedDedupe: ClaimableDedupe | null = null;
+let contentDedupe: ClaimableDedupe | null = null;
 
-function getCliqDedupe(): ClaimableDedupe {
-  if (!dedupe) {
-    dedupe = createClaimableDedupe({
+function getLongLivedCliqDedupe(): ClaimableDedupe {
+  if (!longLivedDedupe) {
+    longLivedDedupe = createClaimableDedupe({
       ttlMs: CLIQ_DEDUPE_TTL_MS,
       memoryMaxSize: CLIQ_DEDUPE_MEMORY_MAX_SIZE,
     });
   }
-  return dedupe;
+  return longLivedDedupe;
+}
+
+function getContentCliqDedupe(): ClaimableDedupe {
+  if (!contentDedupe) {
+    contentDedupe = createClaimableDedupe({
+      ttlMs: CLIQ_CONTENT_DEDUPE_TTL_MS,
+      memoryMaxSize: CLIQ_DEDUPE_MEMORY_MAX_SIZE,
+    });
+  }
+  return contentDedupe;
 }
 
 /**
@@ -68,6 +78,11 @@ function getCliqDedupe(): ClaimableDedupe {
  * ~20 s retries of the same upload are deduped as `duplicate`/`inflight`
  * rather than re-dispatched (which would otherwise trip a
  * "reply session initialization conflicted" loop).
+ *
+ * A composite key (and the `syn:` synthetic id built from the same material)
+ * identifies message *content*, not a message: two deliberate `/status`
+ * commands share one key. Such keys are therefore claimed against the
+ * short-TTL guard, so only a redelivery is suppressed (issue #114).
  */
 export function buildCliqDedupeKey(
   parsed: ParsedCliqInbound,
@@ -90,6 +105,20 @@ export function buildCliqDedupeKey(
 
 export type CliqDedupeClaimKind = "claimed" | "duplicate" | "inflight";
 
+const CLIQ_SYNTHETIC_ID_PREFIX = "syn:";
+
+function usesContentDedupe(parsed: ParsedCliqInbound): boolean {
+  return (
+    !parsed.messageId || parsed.messageId.startsWith(CLIQ_SYNTHETIC_ID_PREFIX)
+  );
+}
+
+function resolveCliqDedupe(parsed: ParsedCliqInbound): ClaimableDedupe {
+  return usesContentDedupe(parsed)
+    ? getContentCliqDedupe()
+    : getLongLivedCliqDedupe();
+}
+
 /**
  * Claim a Cliq message for processing. Returns `null` when there is no stable
  * key to dedupe on (caller should proceed without dedupe). The returned
@@ -102,14 +131,14 @@ export async function claimCliqMessage(
 ): Promise<{ kind: CliqDedupeClaimKind; key: string | null } | null> {
   const key = buildCliqDedupeKey(parsed, account);
   if (!key) return null;
-  const result = await getCliqDedupe().claim(key);
+  const result = await resolveCliqDedupe(parsed).claim(key);
   return { kind: result.kind, key };
 }
 
 /** Record a claimed message as processed so future redeliveries are dropped. */
 export async function commitCliqMessage(key: string | null): Promise<void> {
   if (!key) return;
-  await getCliqDedupe().commit(key);
+  await resolveCliqDedupeForKey(key).commit(key);
 }
 
 /**
@@ -118,13 +147,22 @@ export async function commitCliqMessage(key: string | null): Promise<void> {
  */
 export function releaseCliqMessage(key: string | null, error?: unknown): void {
   if (!key) return;
-  getCliqDedupe().release(key, error !== undefined ? { error } : undefined);
+  resolveCliqDedupeForKey(key).release(
+    key,
+    error !== undefined ? { error } : undefined,
+  );
 }
 
-/** Test helper: clear the in-memory dedupe cache between cases. */
+function resolveCliqDedupeForKey(key: string): ClaimableDedupe {
+  const isContentDerived =
+    key.includes(":cmp:") || key.includes(`:mid:${CLIQ_SYNTHETIC_ID_PREFIX}`);
+  return isContentDerived ? getContentCliqDedupe() : getLongLivedCliqDedupe();
+}
+
+/** Test helper: clear the in-memory dedupe caches between cases. */
 export function resetCliqDedupeForTest(): void {
-  if (dedupe) {
-    dedupe.clearMemory();
-    dedupe = null;
-  }
+  longLivedDedupe?.clearMemory();
+  longLivedDedupe = null;
+  contentDedupe?.clearMemory();
+  contentDedupe = null;
 }

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -396,6 +396,8 @@ function buildUserName(user: NonNullable<CliqWebhookPayload["user"]>): string {
  * timestamp is only included when the payload explicitly provides one
  * (`message.time`); when absent, the hash is stable across Cliq
  * redeliveries (which call `new Date().toISOString()` fresh each time).
+ * Because identical user messages produce the same synthetic id, the dedupe
+ * layer retains `syn:` ids only for the short redelivery window.
  */
 function buildSyntheticMessageId(
   senderId: string,
@@ -411,17 +413,9 @@ function buildSyntheticMessageId(
     // (stable across redeliveries). When absent, `new Date().toISOString()`
     // changes on each delivery → omit it so the hash is deterministic.
     ...(payloadTime ? [payloadTime] : []),
-    // Include the message text so two DIFFERENT messages from the same
-    // sender + chat do not hash to the same id and get wrongly dropped as
-    // duplicates. A Cliq bot Message handler delivers `message` as a bare
-    // string with no `message.id` AND no `message.time`, so without the text
-    // every one of a user's DM messages hashed to the SAME constant id
-    // (`sender + chat`) — and, with the 30-min dedupe TTL, every message after
-    // the first was silently dropped as a "duplicate" until a gateway restart
-    // cleared the in-memory cache. This made slash commands and follow-up
-    // messages appear to work only intermittently. A genuine Cliq redelivery
-    // of the same message carries identical text → identical id → still
-    // correctly deduped.
+    // Include the message text so two DIFFERENT messages from the same sender
+    // and chat do not hash to the same id: without it every DM from a user in
+    // one chat shared a single constant id.
     text,
     ...attachments.map((a) => a.fileId ?? a.fileName ?? ""),
   ];

--- a/src/load.test.ts
+++ b/src/load.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import cliqEntry from "../index.js";
 import { cliqPlugin } from "./channel.js";
@@ -297,6 +297,65 @@ describe("durable-before-ack ingest (issue #12)", () => {
     expect(res2.statusCode).toBe(200);
     // No second dispatch — deduped as duplicate/inflight.
     expect(runCalled).toBe(1);
+  });
+
+  it("dispatches an identical slash command sent again after the content dedupe window (issue #114)", async () => {
+    let runCalled = 0;
+    const { webhook } = buildDurableRegistration({
+      inboundRun: async () => {
+        runCalled++;
+        return undefined;
+      },
+    });
+    const commandPayload = {
+      handler: "mention",
+      message: "/status",
+      user: { id: "fake-user", name: "Test User" },
+      chat: {
+        id: "CT_channel",
+        type: "channel",
+        chat_type: "channel",
+        channel_unique_name: "dev-team",
+        title: "#dev-team",
+      },
+      mentions: [{ id: "bot", name: "openclaw-bot", type: "bot" }],
+    };
+
+    const first = createMockServerResponse();
+    await webhook.handler(
+      createMockIncomingRequest("POST", commandPayload, {
+        "x-cliq-webhook-secret": "s3cr3t",
+      }),
+      first as unknown as any,
+    );
+    expect(first.statusCode).toBe(200);
+    expect(runCalled).toBe(1);
+
+    const redelivery = createMockServerResponse();
+    await webhook.handler(
+      createMockIncomingRequest("POST", commandPayload, {
+        "x-cliq-webhook-secret": "s3cr3t",
+      }),
+      redelivery as unknown as any,
+    );
+    expect(redelivery.statusCode).toBe(200);
+    expect(runCalled).toBe(1);
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(Date.now() + 5 * 60 * 1000));
+      const resend = createMockServerResponse();
+      await webhook.handler(
+        createMockIncomingRequest("POST", commandPayload, {
+          "x-cliq-webhook-secret": "s3cr3t",
+        }),
+        resend as unknown as any,
+      );
+      expect(resend.statusCode).toBe(200);
+      expect(runCalled).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("acks 200 (not 400) for a caption-less image with attachments forwarded (issue #84)", async () => {


### PR DESCRIPTION
## Summary

- use a 60-second dedupe TTL for content-derived `syn:` and composite identities
- keep the 30-minute TTL for real Cliq message ids and plugin-owned event ids
- cover repeated slash commands, short redeliveries, caption-less files, synthetic attachment ids, and real ids
- document the live bare-string Message Handler behavior

## TDD evidence

The regression was added first and failed against the previous production implementation: repeated synthetic-id and composite-key commands were still reported as `duplicate` after five minutes. The same tests pass with this change.

## Verification

- `npx tsc --noEmit`
- `npm test` (61 files, 1470 tests)
- `npm run smoke:gateway`

Closes #114