### PR TITLE
docs(webhook): remove obsolete alternate authentication headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@ publish workflow extracts the matching section as the release notes (see
 
 ### Documentation
 
+- **Corrected the documented webhook authentication headers (issue #128).**
+  The README claimed the endpoint also accepts `x-webhook-secret` or
+  `Authorization: Bearer <secret>` "for convenience". The runtime has always
+  enforced single-header authentication and rejects both, so operators who
+  followed that note configured a header the gateway answers with `401`. Only
+  `x-cliq-webhook-secret` is documented now.
 - Added [docs/setup/public-webhook.md](docs/setup/public-webhook.md): how to
   make the webhook publicly reachable, with five options (VPS + reverse proxy,
   Cloudflare Tunnel, an existing reverse proxy, temporary dev tunnels, and

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ Notes (the parser is tolerant):
 - `message` may be a plain string instead of `{ text, id, time }`.
 - A wrapped `params` object (`{ params: { message, user, channel } }`) is also accepted.
 - Group vs DM detection: `chat.type === "channel"` (or the presence of `channel.*` fields) marks a group; otherwise the message is treated as a DM.
-- The `x-cliq-webhook-secret` header is checked against the configured `webhookSecret`. The plugin also accepts `x-webhook-secret` or `Authorization: Bearer <secret>` for convenience.
+- The `x-cliq-webhook-secret` header is checked against the configured `webhookSecret`. Only `x-cliq-webhook-secret` is accepted; `x-webhook-secret` and `Authorization: Bearer <secret>` are rejected.
 - **Form submissions** (see [§5b](#5b-form-handler-optional--structured-input)): a payload with `handler: "form"` and/or a non-empty `values` object (also accepted under `form.values` / `form_data` / `formvalues`, including inside a `params` wrapper) is recognized as a Cliq Form submission; the submitted field values synthesize the agent body and are surfaced as `FormValues` / `FormName` on the inbound context.
 - **Agent-rendered form button clicks** (see [§5c](#5c-agent-rendered-forms-outbound-structured-input)): a prompt-card button posts `__cliq_form__ <fieldName>=<value>` as the message text; the plugin recognizes the sentinel and surfaces the answer as a `FormValues` entry (`{ <fieldName>: <value> }`) on the inbound context (structured params for a tool call), with the clean `<fieldName>: <value>` rendering as the agent body.
 


### PR DESCRIPTION
## Summary
- document only the canonical `x-cliq-webhook-secret` header
- explicitly reject obsolete alternate-header guidance
- add the required Unreleased changelog entry

Closes #128

Checks: `npx tsc --noEmit`, `npm test`, `npm run smoke:gateway`