### PR TITLE
fix(oauth): ZohoCliq.Bots.CREATE is required to create a bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ publish workflow extracts the matching section as the release notes (see
 
 ### Fixed
 
+- **`ZohoCliq.Bots.CREATE` added to the capability matrix (issue #110).**
+  The setup/maintenance profile previously documented only `Bots.READ` and
+  `Bots.UPDATE`, which suffice to inspect bots but not to create one: a token
+  consented with the full documented set is issued successfully and still
+  fails `POST /api/v3/bots` with `oauthtoken_scope_invalid`. Bot creation is
+  now its own `client_credentials` capability, the setup profile is split
+  into an inspect-only string (`Bots.READ`) and a provisioning string
+  (`Bots.READ,Bots.CREATE,Bots.UPDATE`), the combined consent string
+  includes the new scope, and a missing `Bots.CREATE` produces a message
+  naming that exact scope. Because creating a bot is destructive, the
+  capability is reported from the granted scope set and labelled
+  consent-reported, never proven by a live probe.
 - **Webhook accounts now report as running, configured, and event-driven
   (issue #98).** A configured Cliq account keeps a passive `startAccount`
   lifecycle so OpenClaw does not treat the webhook transport as `stopped` /

--- a/README.md
+++ b/README.md
@@ -207,21 +207,33 @@ ZohoCliq.Webhooks.CREATE,ZohoCliq.Channels.UPDATE,ZohoCliq.Channels.CREATE,ZohoC
 | Media download | `ZohoCliq.Attachments.READ` | refresh_token | no |
 
 **Setup / maintenance profile** — scopes required for bot inspection and handler
-provisioning from `openclaw setup`. These are **not** needed for normal messaging:
+provisioning from `openclaw setup`. These are **not** needed for normal messaging.
+Inspect-only consent (`ZohoCliq.Bots.READ`) can *look* at existing bots but cannot
+create or change anything; provisioning consent additionally includes the create and
+update scopes:
 
 ```
-ZohoCliq.Bots.READ,ZohoCliq.Bots.UPDATE
+ZohoCliq.Bots.READ,ZohoCliq.Bots.CREATE,ZohoCliq.Bots.UPDATE
 ```
 
-| Capability | Scope | Grant |
-|---|---|---|
-| Bot read | `ZohoCliq.Bots.READ` | client_credentials |
-| Bot / handler update | `ZohoCliq.Bots.UPDATE` | client_credentials |
+| Capability | Scope | Grant | Consent tier |
+|---|---|---|---|
+| Bot read (inspect existing bots) | `ZohoCliq.Bots.READ` | client_credentials | inspect-only |
+| Bot create | `ZohoCliq.Bots.CREATE` | client_credentials | provisioning |
+| Bot / handler update | `ZohoCliq.Bots.UPDATE` | client_credentials | provisioning |
+
+> **Inspect vs. create is a real difference.** A token consented with only
+> `Bots.READ` + `Bots.UPDATE` is issued happily (the token response even reports
+> both scopes) but `POST /api/v3/bots` fails with
+> `{"code":"oauthtoken_scope_invalid"}` — the error suggests a bad token when the
+> real cause is the missing `ZohoCliq.Bots.CREATE` consent. Bot creation is
+> destructive to probe, so this capability is reported from the granted scope set,
+> never verified by actually creating a bot.
 
 **Combined profile** — runtime + setup in a single consent:
 
 ```
-ZohoCliq.Webhooks.CREATE,ZohoCliq.Channels.UPDATE,ZohoCliq.Channels.CREATE,ZohoCliq.Channels.READ,ZohoCliq.Users.READ,ZohoCliq.Messages.UPDATE,ZohoCliq.Messages.READ,ZohoCliq.Messages.DELETE,ZohoCliq.messageactions.CREATE,ZohoCliq.Attachments.READ,ZohoCliq.Bots.READ,ZohoCliq.Bots.UPDATE
+ZohoCliq.Webhooks.CREATE,ZohoCliq.Channels.UPDATE,ZohoCliq.Channels.CREATE,ZohoCliq.Channels.READ,ZohoCliq.Users.READ,ZohoCliq.Messages.UPDATE,ZohoCliq.Messages.READ,ZohoCliq.Messages.DELETE,ZohoCliq.messageactions.CREATE,ZohoCliq.Attachments.READ,ZohoCliq.Bots.READ,ZohoCliq.Bots.CREATE,ZohoCliq.Bots.UPDATE
 ```
 
 #### 3c. Obtain the user-context refresh token (required for channel posts + edits)

--- a/src/account-inspect.ts
+++ b/src/account-inspect.ts
@@ -12,6 +12,8 @@ import {
 import {
   ALL_CAPABILITY_SCOPES,
   RUNTIME_SCOPE_STRING,
+  SETUP_INSPECT_SCOPE_STRING,
+  SETUP_PROVISION_SCOPE_STRING,
   SETUP_SCOPE_STRING,
   FULL_SCOPE_STRING,
 } from "./capabilities.js";
@@ -34,13 +36,15 @@ export const CLIQ_OAUTH_SCOPES: readonly string[] = ALL_CAPABILITY_SCOPES;
  *
  * - `RUNTIME` — all scopes needed for normal DM/channel messaging + optional
  *   features (reactions, media, streaming, message read/delete).
- * - `SETUP` — scopes needed for bot read + handler provisioning
- *   (`ZohoCliq.Bots.READ`, `ZohoCliq.Bots.UPDATE`).
- * - `FULL` — combined (runtime + setup) for a single consent that covers
+ * - `SETUP_INSPECT` — `ZohoCliq.Bots.READ` only, for existing-bot inspection.
+ * - `SETUP_PROVISION` — bot read/create/update for bot + handler provisioning.
+ * - `FULL` — combined (runtime + setup provisioning) for a single consent that covers
  *   everything.
  */
 export const CLIQ_SCOPE_PROFILES = {
   runtime: RUNTIME_SCOPE_STRING,
+  setupInspect: SETUP_INSPECT_SCOPE_STRING,
+  setupProvision: SETUP_PROVISION_SCOPE_STRING,
   setup: SETUP_SCOPE_STRING,
   full: FULL_SCOPE_STRING,
 } as const;
@@ -100,7 +104,11 @@ export interface InspectedCliqAccount {
   scopeProfiles: {
     /** All runtime scopes (DM, channel, messaging, rich features). */
     runtime: string;
-    /** Setup/maintenance scopes (bot read, bot update). */
+    /** Inspect-only setup scope (bot read). */
+    setupInspect: string;
+    /** Setup provisioning scopes (bot read/create/update). */
+    setupProvision: string;
+    /** Backward-compatible alias for setup provisioning. */
     setup: string;
     /** Combined (runtime + setup). */
     full: string;

--- a/src/capabilities.test.ts
+++ b/src/capabilities.test.ts
@@ -9,6 +9,7 @@ import {
   FULL_SCOPE_STRING,
   probeCliqCapability,
   formatCapabilityReport,
+  evaluateCliqScopeSet,
   getCapabilityById,
   getCapabilitiesByProfile,
   getRequiredScopesForProfile,
@@ -104,6 +105,94 @@ describe("CLIQ_CAPABILITIES", () => {
     expect(botUpdate.scope).toBe("ZohoCliq.Bots.UPDATE");
   });
 
+  it("Bot create is its own setup capability on the client_credentials grant", () => {
+    const botCreate = getCapabilityById("bot_create")!;
+    expect(botCreate).toBeDefined();
+    expect(botCreate.scope).toBe("ZohoCliq.Bots.CREATE");
+    expect(botCreate.profile).toBe("setup");
+    expect(botCreate.category).toBe("setup");
+    expect(botCreate.grantType).toBe("client_credentials");
+  });
+
+  it("Bot create is reported from the granted scope set, never probed", () => {
+    const botCreate = getCapabilityById("bot_create")!;
+    expect(botCreate.probePath).toBeNull();
+    expect(botCreate.scopeReportedOnly).toBe(true);
+  });
+
+  it("Bot read stays probe-free but is not a scope-reported-only capability", () => {
+    const botRead = getCapabilityById("bot_read")!;
+    expect(botRead.scopeReportedOnly).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope-set evaluation (issue #110)
+// ---------------------------------------------------------------------------
+
+describe("evaluateCliqScopeSet", () => {
+  const runtimeScopes = RUNTIME_SCOPE_STRING.split(",");
+
+  it("reports Bots.CREATE as missing for a READ+UPDATE consent", () => {
+    const granted = [
+      ...runtimeScopes,
+      "ZohoCliq.Bots.READ",
+      "ZohoCliq.Bots.UPDATE",
+    ];
+    const result = evaluateCliqScopeSet(granted);
+    expect(result.missing).toContain("bot_create");
+    expect(result.canCreateBots).toBe(false);
+    expect(result.canInspectBots).toBe(true);
+  });
+
+  it("names ZohoCliq.Bots.CREATE explicitly instead of a generic scope error", () => {
+    const granted = [
+      ...runtimeScopes,
+      "ZohoCliq.Bots.READ",
+      "ZohoCliq.Bots.UPDATE",
+    ];
+    const result = evaluateCliqScopeSet(granted);
+    const message = result.messages.join("\n");
+    expect(message).toContain("ZohoCliq.Bots.CREATE");
+    expect(message).toMatch(/create/i);
+    expect(message).not.toMatch(/^The OAuth token passed does not have/);
+  });
+
+  it("reports bot creation as available once Bots.CREATE is consented", () => {
+    const granted = [
+      ...runtimeScopes,
+      "ZohoCliq.Bots.READ",
+      "ZohoCliq.Bots.CREATE",
+      "ZohoCliq.Bots.UPDATE",
+    ];
+    const result = evaluateCliqScopeSet(granted);
+    expect(result.canCreateBots).toBe(true);
+    expect(result.missing).not.toContain("bot_create");
+  });
+
+  it("marks bot creation as consent-reported, not probed", () => {
+    const granted = [...runtimeScopes, ...SETUP_SCOPE_STRING.split(",")];
+    const result = evaluateCliqScopeSet(granted);
+    expect(result.canCreateBots).toBe(true);
+    expect(result.scopeReportedOnly).toContain("bot_create");
+  });
+
+  it("tolerates whitespace and empty entries in the granted scope list", () => {
+    const result = evaluateCliqScopeSet([
+      " ZohoCliq.Bots.READ ",
+      "",
+      "ZohoCliq.Bots.CREATE",
+    ]);
+    expect(result.canInspectBots).toBe(true);
+    expect(result.canCreateBots).toBe(true);
+  });
+
+  it("accepts a raw comma-separated scope string", () => {
+    const result = evaluateCliqScopeSet("ZohoCliq.Bots.READ,ZohoCliq.Bots.UPDATE");
+    expect(result.canCreateBots).toBe(false);
+    expect(result.missing).toContain("bot_create");
+  });
+
   it("Reactions are optional", () => {
     const react = getCapabilityById("reactions")!;
     expect(react).toBeDefined();
@@ -155,8 +244,9 @@ describe("scope sets", () => {
     }
   });
 
-  it("SETUP_SCOPES includes Bots.READ and Bots.UPDATE", () => {
+  it("SETUP_SCOPES includes Bots.READ, Bots.CREATE, and Bots.UPDATE", () => {
     expect(SETUP_SCOPES).toContain("ZohoCliq.Bots.READ");
+    expect(SETUP_SCOPES).toContain("ZohoCliq.Bots.CREATE");
     expect(SETUP_SCOPES).toContain("ZohoCliq.Bots.UPDATE");
   });
 
@@ -189,8 +279,9 @@ describe("canonical scope strings", () => {
     }
   });
 
-  it("SETUP_SCOPE_STRING contains Bots.READ and Bots.UPDATE", () => {
+  it("SETUP_SCOPE_STRING contains Bots.READ, Bots.CREATE, and Bots.UPDATE", () => {
     expect(SETUP_SCOPE_STRING).toContain("ZohoCliq.Bots.READ");
+    expect(SETUP_SCOPE_STRING).toContain("ZohoCliq.Bots.CREATE");
     expect(SETUP_SCOPE_STRING).toContain("ZohoCliq.Bots.UPDATE");
   });
 
@@ -475,6 +566,7 @@ describe("getRequiredScopesForProfile", () => {
   it("returns required setup scopes", () => {
     const scopes = getRequiredScopesForProfile("setup");
     expect(scopes).toContain("ZohoCliq.Bots.READ");
+    expect(scopes).toContain("ZohoCliq.Bots.CREATE");
     expect(scopes).toContain("ZohoCliq.Bots.UPDATE");
   });
 
@@ -494,7 +586,7 @@ describe("grant type requirements", () => {
   it("client_credentials scopes are for DM and directory operations", () => {
     const ccCaps = CLIQ_CAPABILITIES.filter((c) => c.grantType === "client_credentials");
     for (const cap of ccCaps) {
-      expect(["ZohoCliq.Webhooks.CREATE", "ZohoCliq.Users.READ", "ZohoCliq.Channels.READ", "ZohoCliq.Bots.READ", "ZohoCliq.Bots.UPDATE"]).toContain(cap.scope);
+      expect(["ZohoCliq.Webhooks.CREATE", "ZohoCliq.Users.READ", "ZohoCliq.Channels.READ", "ZohoCliq.Bots.READ", "ZohoCliq.Bots.CREATE", "ZohoCliq.Bots.UPDATE"]).toContain(cap.scope);
     }
   });
 

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -76,6 +76,7 @@ export interface CliqCapability {
    * which scope is missing and how to regenerate the token.
    */
   readonly missingHint: string;
+  readonly scopeReportedOnly?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -235,6 +236,20 @@ export const CLIQ_CAPABILITIES: readonly CliqCapability[] = [
       "Bot inspection requires the ZohoCliq.Bots.READ scope. Re-consent your self-client with this scope and regenerate the token.",
   },
   {
+    id: "bot_create",
+    label: "Bot create",
+    scope: "ZohoCliq.Bots.CREATE",
+    grantType: "client_credentials",
+    profile: "setup",
+    category: "setup",
+    optional: false,
+    probePath: null,
+    probeMethod: "GET",
+    missingHint:
+      "Creating a bot requires the ZohoCliq.Bots.CREATE scope. A token with only Bots.READ and Bots.UPDATE can inspect and update existing bots but POST /api/v3/bots will fail. Re-consent your self-client with ZohoCliq.Bots.CREATE and regenerate the token.",
+    scopeReportedOnly: true,
+  },
+  {
     id: "bot_update",
     label: "Bot / handler update",
     scope: "ZohoCliq.Bots.UPDATE",
@@ -300,13 +315,20 @@ export const RUNTIME_SCOPE_STRING = [
 
 /**
  * Canonical comma-separated scope string for the **setup/maintenance**
- * profile — bot read + bot update. Added alongside the runtime scopes when
- * the operator also needs handler provisioning from `openclaw setup`.
+ * profile — inspect existing bots. Add `SETUP_PROVISION_SCOPE_STRING` to
+ * create new bots and configure their handlers from `openclaw setup`.
  */
-export const SETUP_SCOPE_STRING = [
+export const SETUP_INSPECT_SCOPE_STRING = "ZohoCliq.Bots.READ";
+
+/** Setup profile for bot creation and handler provisioning. */
+export const SETUP_PROVISION_SCOPE_STRING = [
   "ZohoCliq.Bots.READ",
+  "ZohoCliq.Bots.CREATE",
   "ZohoCliq.Bots.UPDATE",
 ].join(",");
+
+/** Backward-compatible setup alias for the complete provisioning profile. */
+export const SETUP_SCOPE_STRING = SETUP_PROVISION_SCOPE_STRING;
 
 /**
  * Combined scope string (runtime + setup) for a single consent that covers
@@ -316,6 +338,47 @@ export const FULL_SCOPE_STRING = [
   RUNTIME_SCOPE_STRING,
   SETUP_SCOPE_STRING,
 ].join(",");
+
+export interface CliqScopeSetEvaluation {
+  readonly granted: readonly string[];
+  readonly available: readonly string[];
+  readonly missing: readonly string[];
+  readonly scopeReportedOnly: readonly string[];
+  readonly messages: readonly string[];
+  readonly canInspectBots: boolean;
+  readonly canCreateBots: boolean;
+}
+
+export function evaluateCliqScopeSet(
+  grantedScopes: string | readonly string[],
+): CliqScopeSetEvaluation {
+  const rawScopes = typeof grantedScopes === "string"
+    ? grantedScopes.split(",")
+    : grantedScopes;
+  const granted = [...new Set(rawScopes.map((scope) => scope.trim()).filter(Boolean))];
+  const grantedSet = new Set(granted);
+  const available = CLIQ_CAPABILITIES
+    .filter((capability) => grantedSet.has(capability.scope))
+    .map((capability) => capability.id);
+  const missingCapabilities = CLIQ_CAPABILITIES.filter(
+    (capability) => !grantedSet.has(capability.scope),
+  );
+  const scopeReportedOnly = CLIQ_CAPABILITIES
+    .filter(
+      (capability) => capability.scopeReportedOnly && grantedSet.has(capability.scope),
+    )
+    .map((capability) => capability.id);
+
+  return {
+    granted,
+    available,
+    missing: missingCapabilities.map((capability) => capability.id),
+    scopeReportedOnly,
+    messages: missingCapabilities.map((capability) => capability.missingHint),
+    canInspectBots: grantedSet.has("ZohoCliq.Bots.READ"),
+    canCreateBots: grantedSet.has("ZohoCliq.Bots.CREATE"),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Probe result types


### PR DESCRIPTION
## Summary
- add `bot_create` (`ZohoCliq.Bots.CREATE`, client_credentials) to the capability matrix
- split the setup profile into inspect-only and provisioning scope strings
- surface a missing `Bots.CREATE` with a message naming that exact scope
- report bot creation from the granted scope set instead of probing it (creating a bot is destructive)
- update the README setup + combined scope strings and add a changelog entry

## Verification
TDD: tests written first and observed failing, then made to pass.
`npx tsc --noEmit`, `npm test` (1546 passed), `npm run smoke:gateway` all pass locally.

Closes #110