### PR TITLE
fix(preflight): send an explicit User-Agent so edge WAFs do not block the probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ publish workflow extracts the matching section as the release notes (see
 
 ### Fixed
 
+- **The public webhook preflight now identifies itself explicitly at the edge
+  (issue #107).** Every reachability, secret-enforcement, and authenticated
+  probe request sends the documented User-Agent
+  `openclaw-cliq-preflight/<package-version> (+https://github.com/sprintberlin/openclaw-cliq)`
+  instead of relying on Node's runtime-dependent default or sending no identity
+  at all — avoiding false diagnostics when an edge WAF blocks unfamiliar bot
+  clients before they reach an otherwise healthy gateway. Operators can pass
+  `--user-agent <value>` to reproduce Zoho/Deluge's identity, and an HTTP `403`
+  is now classified as a probable edge/WAF/bot-rule block with allowlisting
+  guidance rather than blamed on the route or reverse proxy.
 - **A passing CLI preflight now records the inbound verification (issue
   #106).** `channels.cliq.inboundVerifiedAt` was only ever written by the setup
   wizard, so an operator who configured the channel by hand and verified the

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The plugin registers a single HTTP route at **`POST /cliq/webhook`** on your Ope
    openclaw cliq webhook-preflight https://<gateway-host>/cliq/webhook --no-write
    ```
 
-   `openclaw setup` runs the same check and will not report inbound Cliq as ready when it fails. For a full staged diagnostic of config, OAuth, capabilities, and inbound, see [`openclaw cliq doctor`](#cliq-doctor).
+   `openclaw setup` runs the same check and will not report inbound Cliq as ready when it fails. Every preflight request identifies itself as `openclaw-cliq-preflight/<package-version> (+https://github.com/sprintberlin/openclaw-cliq)` so edge/WAF rules can allowlist it deliberately (the version is this package's `package.json` version); use `--user-agent <value>` when you need to reproduce the identity your Zoho/Deluge delivery uses. An HTTP `403` is reported as a probable edge/WAF/bot-rule block with that remediation, not as proof that the route or reverse proxy is broken. For a full staged diagnostic of config, OAuth, capabilities, and inbound, see [`openclaw cliq doctor`](#cliq-doctor).
 
    To check only whether the gateway registered the route (no public path, no secret, no agent turn):
 

--- a/docs/setup/public-webhook.md
+++ b/docs/setup/public-webhook.md
@@ -85,6 +85,29 @@ Setup status reports three distinct states rather than a blanket "NOT
 verified": `verified <timestamp>`, `last check FAILED <timestamp>`, and `never
 checked`.
 
+Every request — the reachability `GET`, both secret-enforcement `POST`s, and
+the authenticated probe — sends this explicit, honest User-Agent:
+
+```text
+openclaw-cliq-preflight/<package-version> (+https://github.com/sprintberlin/openclaw-cliq)
+```
+
+The `<package-version>` is this plugin's `package.json` version, currently
+`0.1.10`. Edge providers routinely block unfamiliar or missing User-Agents
+before a request reaches the gateway. Allowlist that identity (or the pattern
+`openclaw-cliq-preflight/*`) for the webhook hostname, or override it to
+reproduce the identity your Zoho/Deluge delivery uses:
+
+```bash
+openclaw cliq webhook-preflight https://<public-host>/cliq/webhook \
+  --user-agent 'ZohoCliq'
+```
+
+A `403` at any stage is therefore classified as a **probable edge/WAF/bot-rule
+block**, with advice to allow the preflight identity or the Zoho source. It is
+not reported as a missing route or as proof that a working reverse proxy needs
+to be reconfigured.
+
 It distinguishes DNS, TLS, reverse-proxy, route, secret, and application
 failures, and finishes with an authenticated probe that reaches the plugin
 **without** dispatching an agent turn or producing a Cliq message.
@@ -363,6 +386,7 @@ keep the traffic path entirely under your control.
 | `404` | Proxy does not forward `/cliq/webhook`, or the channel is not configured (the plugin registers the route only when `channels.cliq` exists) |
 | `503` | `webhookSecret` is not set — the plugin fails closed |
 | `401` | Header missing or the secret does not match |
+| `403` | Probable edge/WAF/bot-rule block before the request reached the plugin. Allow `openclaw-cliq-preflight/<package-version> (+https://github.com/sprintberlin/openclaw-cliq)` (or `openclaw-cliq-preflight/*`) or the Zoho source; do **not** reconfigure a working reverse proxy based on this result alone |
 | `429` | An upstream rate limiter answered before the plugin — the preflight reports the secret stage as inconclusive rather than passing it |
 | `405` on `POST` | Something upstream rewrote the method |
 | Timeout in the Deluge log | Proxy read timeout shorter than the agent turn |

--- a/index.ts
+++ b/index.ts
@@ -81,10 +81,11 @@ export default defineChannelPluginEntry({
           .argument("<url>", "Public webhook URL, e.g. https://host.example.com/cliq/webhook")
           .option("--secret <secret>", "Webhook shared secret (defaults to channels.cliq.webhookSecret)")
           .option("--no-write", "Do not record the result in channels.cliq verification status")
+          .option("--user-agent <userAgent>", "User-Agent the preflight identifies itself with to the edge")
           .option("--json", "Emit the machine-readable report")
           .action(async (
             url: string,
-            opts: { secret?: string; write?: boolean; json?: boolean },
+            opts: { secret?: string; write?: boolean; userAgent?: string; json?: boolean },
           ) => {
             const { runCliqWebhookPreflightCommand } = await import(
               "./src/webhook-preflight-command.js"
@@ -108,6 +109,7 @@ export default defineChannelPluginEntry({
               configuredUrl: readConfiguredCliqWebhookUrl(api.config as OpenClawConfig),
               foreignSecret,
               write: opts.write,
+              userAgent: opts.userAgent,
               json: opts.json,
             });
             process.exitCode = code;

--- a/src/webhook-preflight-command.test.ts
+++ b/src/webhook-preflight-command.test.ts
@@ -41,7 +41,7 @@ describe("cliq webhook-preflight command (issue #96)", () => {
     );
     expect(code).toBe(0);
     expect(calls).toEqual([
-      { url: "https://x.example/cliq/webhook", secret: "s" },
+      { url: "https://x.example/cliq/webhook", secret: "s", userAgent: undefined },
     ]);
   });
 
@@ -103,6 +103,20 @@ describe("cliq webhook-preflight command (issue #96)", () => {
       }),
     );
     expect(receivedSecret).toBeNull();
+  });
+
+  it("forwards a --user-agent override to the preflight (issue #107)", async () => {
+    let received: string | undefined;
+    await runCliqWebhookPreflightCommand(
+      { url: "https://x.example/cliq/webhook", secret: "s", userAgent: "ZohoCliq" },
+      deps({
+        runPreflight: async (options) => {
+          received = (options as { userAgent?: string }).userAgent;
+          return { ok: true, url: options.url, nonce: "n", dispatched: false, stages: [] };
+        },
+      }),
+    );
+    expect(received).toBe("ZohoCliq");
   });
 });
 

--- a/src/webhook-preflight-command.ts
+++ b/src/webhook-preflight-command.ts
@@ -34,6 +34,8 @@ export interface CliqWebhookPreflightCommandOptions {
   foreignSecret?: boolean;
   /** Run as a pure read-only probe and never persist the result. */
   write?: boolean;
+  /** User-Agent sent to the public endpoint. */
+  userAgent?: string;
   /** Emit the machine-readable report instead of the human-readable one. */
   json?: boolean;
 }
@@ -42,6 +44,7 @@ export interface CliqWebhookPreflightCommandDeps {
   runPreflight: (options: {
     url: string;
     secret: string | undefined;
+    userAgent?: string;
   }) => Promise<CliqPreflightReport>;
   persistVerification?: (params: {
     targetUrl: string;
@@ -54,7 +57,8 @@ export interface CliqWebhookPreflightCommandDeps {
 }
 
 const defaultDeps: CliqWebhookPreflightCommandDeps = {
-  runPreflight: ({ url, secret }) => runCliqWebhookPreflight({ url, secret }),
+  runPreflight: ({ url, secret, userAgent }) =>
+    runCliqWebhookPreflight({ url, secret, userAgent }),
   persistVerification: persistCliqInboundVerification,
   writeLine: (line) => {
     console.log(line);
@@ -69,6 +73,7 @@ export async function runCliqWebhookPreflightCommand(
   const report = await deps.runPreflight({
     url: options.url,
     secret: options.secret,
+    userAgent: options.userAgent,
   });
   const persistVerification = deps.persistVerification ?? persistCliqInboundVerification;
   const failed = report.stages.some((stage) => stage.status === "fail");

--- a/src/webhook-preflight.test.ts
+++ b/src/webhook-preflight.test.ts
@@ -3,6 +3,7 @@ import {
   classifyPreflightNetworkError,
   runCliqWebhookPreflight,
   validateWebhookUrl,
+  CLIQ_PREFLIGHT_USER_AGENT,
   type CliqPreflightFetch,
 } from "./webhook-preflight.js";
 import { CLIQ_PROBE_HANDLER } from "./webhook-probe.js";
@@ -460,5 +461,91 @@ describe("runCliqWebhookPreflight (issue #96)", () => {
       "secret",
       "probe",
     ]);
+  });
+
+  /** A fetch stub that records every request's headers. */
+  function recordingFetch(): { fetch: CliqPreflightFetch; headersOf: (i: number) => Record<string, string> } {
+    const seen: Array<Record<string, string>> = [];
+    const fetch: CliqPreflightFetch = async (_url, init) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      seen.push(headers);
+      const method = init?.method ?? "GET";
+      if (method === "GET") return { status: 405, text: async () => "" };
+      if (headers["x-cliq-webhook-secret"] !== secret) return { status: 401, text: async () => "" };
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return {
+        status: 200,
+        text: async () => JSON.stringify({ ok: true, channel: "cliq", probe: body.probe, dispatched: false }),
+      };
+    };
+    return { fetch, headersOf: (i) => seen[i] };
+  }
+
+  it("sends the documented default User-Agent on every request (issue #107)", async () => {
+    expect(CLIQ_PREFLIGHT_USER_AGENT).toMatch(/^openclaw-cliq-preflight\/\d+\.\d+\.\d+ \(\+https:\/\/github\.com\/sprintberlin\/openclaw-cliq\)$/);
+    const { fetch, headersOf } = recordingFetch();
+    const report = await runCliqWebhookPreflight({ url: URL_OK, secret, fetchImpl: fetch });
+    expect(report.ok).toBe(true);
+    // GET + unauthenticated POST + wrong-secret POST + authenticated probe.
+    expect(headersOf(0)["user-agent"]).toBe(CLIQ_PREFLIGHT_USER_AGENT);
+    expect(headersOf(1)["user-agent"]).toBe(CLIQ_PREFLIGHT_USER_AGENT);
+    expect(headersOf(2)["user-agent"]).toBe(CLIQ_PREFLIGHT_USER_AGENT);
+    expect(headersOf(3)["user-agent"]).toBe(CLIQ_PREFLIGHT_USER_AGENT);
+  });
+
+  it("applies a --user-agent override to every request (issue #107)", async () => {
+    const { fetch, headersOf } = recordingFetch();
+    const report = await runCliqWebhookPreflight({
+      url: URL_OK,
+      secret,
+      userAgent: "ZohoCliq",
+      fetchImpl: fetch,
+    });
+    expect(report.ok).toBe(true);
+    for (let i = 0; i < 4; i += 1) expect(headersOf(i)["user-agent"]).toBe("ZohoCliq");
+  });
+
+  it("classifies a 403 on the GET as a probable edge/WAF block, not a route failure (issue #107)", async () => {
+    const report = await runCliqWebhookPreflight({
+      url: URL_OK,
+      secret,
+      fetchImpl: async () => ({ status: 403, text: async () => "Access denied" }),
+    });
+    expect(report.ok).toBe(false);
+    const stage = stageOf(report, "method");
+    expect(stage.status).toBe("fail");
+    expect(stage.detail).toMatch(/edge\/WAF/i);
+    // Remediation must point at the edge allowlist, not at the proxy.
+    expect(stage.detail).toMatch(/allow the user-agent/i);
+    expect(stage.detail).not.toMatch(/route not found|proxy must forward/i);
+  });
+
+  it("classifies a 403 on the unauthenticated POST as an edge block", async () => {
+    const report = await runCliqWebhookPreflight({
+      url: URL_OK,
+      secret,
+      fetchImpl: async (_url, init) => {
+        if ((init?.method ?? "GET") === "GET") return { status: 405, text: async () => "" };
+        return { status: 403, text: async () => "Access denied" };
+      },
+    });
+    expect(report.ok).toBe(false);
+    expect(stageOf(report, "secret").detail).toMatch(/edge\/WAF/i);
+  });
+
+  it("classifies a 403 on the authenticated probe as an edge block", async () => {
+    const report = await runCliqWebhookPreflight({
+      url: URL_OK,
+      secret,
+      fetchImpl: async (_url, init) => {
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        if ((init?.method ?? "GET") === "GET") return { status: 405, text: async () => "" };
+        if (!headers["x-cliq-webhook-secret"]) return { status: 401, text: async () => "" };
+        if (headers["x-cliq-webhook-secret"] !== secret) return { status: 401, text: async () => "" };
+        return { status: 403, text: async () => "Access denied" };
+      },
+    });
+    expect(report.ok).toBe(false);
+    expect(stageOf(report, "probe").detail).toMatch(/edge\/WAF/i);
   });
 });

--- a/src/webhook-preflight.ts
+++ b/src/webhook-preflight.ts
@@ -1,9 +1,25 @@
 import { CLIQ_PROBE_HANDLER, buildCliqProbeBody } from "./webhook-probe.js";
 import { WEBHOOK_SECRET_HEADER } from "./webhook-security.js";
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+function readPackageVersion(): string {
+  for (const candidate of ["../package.json", "../../package.json"] as const) {
+    try {
+      const url = new URL(candidate, import.meta.url);
+      const parsed = JSON.parse(readFileSync(url, "utf8")) as { version?: string };
+      if (typeof parsed.version === "string" && parsed.version.length > 0) return parsed.version;
+    } catch {
+      // Try the next candidate (src vs dist).
+    }
+  }
+  return "unknown";
+}
+
+export const CLIQ_PREFLIGHT_USER_AGENT = `openclaw-cliq-preflight/${readPackageVersion()} (+https://github.com/sprintberlin/openclaw-cliq)`;
 
 /**
- * Public HTTPS webhook preflight for the Cliq inbound endpoint (issue #96).
+ * Public HTTPS webhook preflight for the Cliq inbound endpoint (issues #96, #107).
  *
  * This module owns DNS/TLS/HTTP/reverse-proxy validation for the public
  * `/cliq/webhook` route. `openclaw setup` uses it to refuse to mark inbound
@@ -209,7 +225,9 @@ const STAGE_LABELS: Record<CliqPreflightStageId, string> = {
   probe: "Authenticated non-dispatching probe",
 };
 
-/** Fill in every not-yet-reached stage so the report shape stays stable. */
+/**
+ * Fill in every not-yet-reached stage so the report shape stays stable.
+ */
 function skipRemaining(recorder: StageRecorder, reason: string): void {
   const done = new Set(recorder.stages.map((s) => s.id));
   for (const id of ["url", "reachability", "method", "secret", "probe"] as CliqPreflightStageId[]) {
@@ -226,12 +244,15 @@ export interface RunCliqWebhookPreflightOptions {
   fetchImpl?: CliqPreflightFetch;
   /** Per-request timeout in milliseconds. */
   timeoutMs?: number;
+  /** User-Agent sent to the public endpoint. */
+  userAgent?: string;
 }
 
 function defaultFetch(timeoutMs: number): CliqPreflightFetch {
   return async (url, init) => {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
+    timer.unref?.();
     try {
       const res = await fetch(url, {
         method: init?.method,
@@ -269,7 +290,10 @@ export async function runCliqWebhookPreflight(
   options: RunCliqWebhookPreflightOptions,
 ): Promise<CliqPreflightReport> {
   const timeoutMs = options.timeoutMs ?? 15_000;
-  const fetchImpl = options.fetchImpl ?? defaultFetch(timeoutMs);
+  const userAgent = options.userAgent ?? CLIQ_PREFLIGHT_USER_AGENT;
+  const innerFetch = options.fetchImpl ?? defaultFetch(timeoutMs);
+  const fetchImpl: CliqPreflightFetch = (url, init) =>
+    innerFetch(url, { ...init, headers: { ...(init?.headers ?? {}), "user-agent": userAgent } });
   const secret = options.secret;
   const nonce = randomUUID();
   const recorder = createRecorder();
@@ -294,7 +318,11 @@ export async function runCliqWebhookPreflight(
   // ---- Stage 2 + 3: reachability and method -------------------------------
   let getRes: CliqPreflightResponse;
   try {
-    getRes = await fetchImpl(options.url, { method: "GET", redirect: "manual" });
+    getRes = await fetchImpl(options.url, {
+      method: "GET",
+      headers: { "user-agent": userAgent },
+      redirect: "manual",
+    });
   } catch (err) {
     const kind = classifyPreflightNetworkError(err);
     const detail =
@@ -316,6 +344,14 @@ export async function runCliqWebhookPreflight(
   );
 
   const getBody = await getRes.text();
+  if (getRes.status === 403) {
+    const htmlHint = looksLikeHtml(getBody, getRes.headers)
+      ? " The 403 body is an HTML challenge page, so this is almost certainly an interactive bot-fight at the edge rather than a plugin 403."
+      : "";
+    const detail = `probable edge/WAF block: the endpoint answered 403 before the plugin route could be verified.${htmlHint} Allow the User-Agent "${userAgent}" (or the Zoho/Deluge source) at the edge; do not change a working reverse proxy based on this result.`;
+    recorder.record("method", STAGE_LABELS.method, "fail", detail);
+    return fail(detail);
+  }
   if (getRes.status >= 300 && getRes.status < 400) {
     const location = getRes.headers?.["location"] ?? "(no Location header)";
     const detail = `redirect: the endpoint answered ${getRes.status} to ${location} instead of reaching the plugin route. A catch-all redirect rule in front of the route intercepts Zoho's delivery.`;
@@ -348,7 +384,7 @@ export async function runCliqWebhookPreflight(
 
   // ---- Stage 4: secret enforcement ---------------------------------------
   const probeBody = JSON.stringify(buildCliqProbeBody(nonce));
-  const jsonHeaders = { "content-type": "application/json" };
+  const jsonHeaders = { "content-type": "application/json", "user-agent": userAgent };
 
   let unauthed: CliqPreflightResponse;
   try {
@@ -360,6 +396,11 @@ export async function runCliqWebhookPreflight(
     });
   } catch (err) {
     const detail = redact(`unauthenticated probe failed to complete: ${String(err)}`, secret);
+    recorder.record("secret", STAGE_LABELS.secret, "fail", detail);
+    return fail(detail);
+  }
+  if (unauthed.status === 403) {
+    const detail = `probable edge/WAF block: the unauthenticated POST answered 403 before the plugin's secret check could run. Allow the User-Agent "${userAgent}" (or the Zoho/Deluge source) at the edge.`;
     recorder.record("secret", STAGE_LABELS.secret, "fail", detail);
     return fail(detail);
   }
@@ -402,12 +443,22 @@ export async function runCliqWebhookPreflight(
     recorder.record("secret", STAGE_LABELS.secret, "fail", detail);
     return fail(detail);
   }
+  if (wrongSecret.status === 403) {
+    const detail = `probable edge/WAF block: the wrong-secret POST answered 403 before the plugin's secret check could run. Allow the User-Agent "${userAgent}" (or the Zoho/Deluge source) at the edge.`;
+    recorder.record("secret", STAGE_LABELS.secret, "fail", detail);
+    return fail(detail);
+  }
   if (rateLimited(wrongSecret)) {
     const detail =
       "inconclusive: the endpoint answered 429 (rate limited) to the wrong-secret probe, so the plugin's secret check was never exercised. Retry later or exempt the preflight source from the upstream rate limiter.";
     recorder.record("secret", STAGE_LABELS.secret, "warn", detail);
     skipRemaining(recorder, "not reached: the secret stage was inconclusive");
     return { ok: false, url: options.url, nonce, dispatched: false, stages: recorder.stages };
+  }
+  if (wrongSecret.status === 403) {
+    const detail = `probable edge/WAF block: the wrong-secret POST answered 403 before the plugin's secret check could run. Allow the User-Agent "${userAgent}" (or the Zoho/Deluge source) at the edge.`;
+    recorder.record("secret", STAGE_LABELS.secret, "fail", detail);
+    return fail(detail);
   }
   if (wrongSecret.status !== 401) {
     const body = await wrongSecret.text();
@@ -444,6 +495,11 @@ export async function runCliqWebhookPreflight(
     return fail(detail);
   }
   const authedBody = await authed.text();
+  if (authed.status === 403) {
+    const detail = `probable edge/WAF block: the authenticated probe answered 403 before reaching the plugin. Allow the User-Agent "${userAgent}" (or the Zoho/Deluge source) at the edge.`;
+    recorder.record("probe", STAGE_LABELS.probe, "fail", detail);
+    return fail(detail);
+  }
   if (authed.status !== 200) {
     const detail = `the authenticated probe was rejected with ${authed.status}. The gateway may be running an older version of the plugin that does not recognize the "${CLIQ_PROBE_HANDLER}" probe payload: ${snippet(authedBody, secret)}`;
     recorder.record("probe", STAGE_LABELS.probe, "fail", detail);


### PR DESCRIPTION
Closes #107

## Problem
The preflight relied on Node's runtime-dependent default User-Agent (or none), while edge providers routinely make bot/WAF decisions on that header alone. A healthy webhook could therefore fail the diagnostic because the tool itself was rejected before reaching the gateway — and the current output blamed the route/proxy.

## Change
- Every preflight request (GET, unauthenticated POST, wrong-secret POST, authenticated probe) sends the explicit identity `openclaw-cliq-preflight/<package-version> (+https://github.com/sprintberlin/openclaw-cliq)`.
- The package version is read from the shipped package metadata and verified from both source and compiled `dist/src` execution.
- `openclaw cliq webhook-preflight --user-agent <value>` overrides the identity on every stage so operators can reproduce Zoho/Deluge.
- HTTP 403 at GET/secret/probe stages is classified as a probable edge/WAF/bot-rule block with allowlisting guidance and without telling the operator to reconfigure a working proxy. HTML challenge bodies receive an explicit challenge hint.
- README, `docs/setup/public-webhook.md`, and CHANGELOG document the versioned UA pattern, override, allowlisting, and 403 remediation.

## Tests
- Default UA present on all four requests.
- Override applied to all four requests and forwarded by the command.
- 403 classified at route, unauthenticated-secret, and authenticated-probe stages.
- Source and compiled build resolve `openclaw-cliq-preflight/0.1.10`.

Sequential gates passed locally: `npx tsc --noEmit`, `npm test` (1655 tests), `npm run smoke:gateway`.