### PR TITLE
feat(setup): provision bots and handlers idempotently with Zoho API fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ publish workflow extracts the matching section as the release notes (see
 
 ### Added
 
+- **Idempotent bot and handler provisioning from `openclaw setup` (issue #94).**
+  Setup now inspects the Zoho-held Message and Mention handlers (plus the
+  Welcome handler when the greeting is opted in) and reports a redacted
+  read-only dry-run before offering any change. Missing handlers are created;
+  when Zoho answers the full-script create with a generic `operation_failed`,
+  a minimal handler is created and then completed with `PATCH`, and that
+  fallback stays visible in the report. `execution_handler_update_failed` is
+  reported as a probable script-validity fault rather than retried, because
+  the Mention Handler does not receive the `attachments` parameter. Every
+  mutation needs its own explicit confirmation that defaults to no, and each
+  write is read back and only reported as successful when Zoho stored the
+  configured URL and secret.
+  **"Bot exists, handlers exist, URL matches, secret does NOT" is treated as
+  a first-class conflict**, never as "already configured, nothing to do": a
+  matching unique name is not proof that a bot belongs to this deployment,
+  and that exact state otherwise yields a green preflight while real inbound
+  traffic is rejected with `401`. An unreadable handler, an unrecognised
+  hand-written script, and a bot whose Zoho-derived unique name differs from
+  `channels.cliq.botId` all block instead of being overwritten. Handler
+  bodies, secrets, and OAuth material never reach the plan, the wizard notes,
+  or any report — only SHA-256 fingerprints.
+
 - **Read-only bot/subscription inspection and consented first-contact onboarding
   (issue #99).** `openclaw setup` can now resolve an optional user and channel
   by name, email, id, or handle through the existing directory adapter; show

--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ Every field except the required ones has a sensible default; `groups` / `thinkin
 
 The Cliq bot must forward every mention / message event to the OpenClaw webhook. The two handlers use **almost** the same script, but they are **not** interchangeable — see the note after the script.
 
+> **`openclaw setup` can do this for you.** When `publicWebhookUrl` is configured and the OAuth client carries the provisioning scopes from [§3b](#3b-oauth-scopes), setup shows a **read-only dry-run** of the Zoho-held handlers and then offers to create or repair them; the Welcome handler is included only when the greeting is opted in. Nothing is changed without a separate confirmation that defaults to *no*. A handler whose URL matches but whose **secret differs** is reported as a conflict rather than "already configured" — that state passes the preflight while real inbound traffic fails with `401`. Unreadable and hand-written handlers are never overwritten, and every write is read back before it counts as successful. The steps below remain the manual path, and are still the correct route when you prefer not to grant `ZohoCliq.Bots.CREATE` / `ZohoCliq.Bots.UPDATE`.
+
 > **Where to find them:** in the Cliq Bot editor open **Edit Handlers**, then click *Edit Code* on **Message Handler** (DMs) and **Mention Handler** (channel @mentions) — the two arrowed below.
 
 <p align="center">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,9 +60,9 @@ v3 adds CRUD endpoints v2 never had (bots, slash commands, message actions, widg
   <https://www.zoho.com/cliq/help/restapi/v3/>. (Prior art: octo's single management tool.)
 - **Schedulers / proactive messages.** Use the v3 scheduler CRUD to let the agent schedule or
   cancel proactive messages. Ref: REST API v3 (schedulers).
-- **Setup-wizard auto-provisioning.** Register the bot, slash-commands, and message-actions via v3
-  CRUD from `openclaw setup` instead of the manual Deluge / console steps in today's guide.
-  Ref: REST API v3.
+- **Setup-wizard auto-provisioning for slash-commands and message-actions.** Register them via v3
+  CRUD from `openclaw setup` instead of the manual console steps in today's guide, reusing the
+  existing bot/handler provisioning service. Ref: REST API v3.
 
 ## Phase 5 — Scaling & operations
 
@@ -72,10 +72,9 @@ Mostly v3-independent; **dynamic agents** in particular is high-value and can be
   user and one group channel still round-trip under the acknowledged trusted-organization
   configuration, and that `openclaw security audit` reports the deployment as informational
   rather than critical. Negative tenant cases must stay on fixtures or an isolated setup.
-- **Read-only bot and handler inspection.** Extend the shared inspector with the remaining #94
-  provisioning dry-run metadata: handler JSON transport structure and a redacted structural diff
-  suitable for the future mutation-confirmation gate. Keep every unreadable field explicitly
-  `unknown`; never infer it from a successful network probe.
+- **Live provisioning acceptance run.** Confirm on a real organization that the setup dry-run
+  matches the Franzi Message/Mention handlers without mutating them, and exercise create plus the
+  minimal-create-then-`PATCH` fallback against an isolated test bot rather than a production one.
 - **Dynamic agents + workspace templates.** Route each DM sender and each channel to its own
   isolated agent session and workspace, seeded on first contact from a configurable template
   (`AGENTS.md` and friends). Today all senders share one agent context; per-channel *tool policy*

--- a/src/bot-provisioning-apply.test.ts
+++ b/src/bot-provisioning-apply.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyCliqHandlerProvisioning,
+  isRetryableCliqProvisioningFailure,
+  type CliqProvisioningWriter,
+} from "./bot-provisioning.js";
+
+const URL_OK = "https://cliq.example.com/cliq/webhook";
+const SECRET = "config-secret";
+const BOT_ID = "b-464329000000074001";
+
+function writer(overrides: Partial<CliqProvisioningWriter> = {}): CliqProvisioningWriter {
+  return {
+    createHandler: vi.fn(async () => ({ ok: true as const })),
+    updateHandler: vi.fn(async () => ({ ok: true as const })),
+    readHandlerScript: vi.fn(async () => ({
+      script: `webhookUrl = "${URL_OK}";\nwebhookSecret = "${SECRET}";`,
+    })),
+    ...overrides,
+  };
+}
+
+function apply(params: {
+  writer?: CliqProvisioningWriter;
+  confirmed?: boolean;
+  items?: Parameters<typeof applyCliqHandlerProvisioning>[0]["plan"]["items"];
+} = {}) {
+  return applyCliqHandlerProvisioning({
+    plan: {
+      status: "changes_required",
+      botId: BOT_ID,
+      configuredUniqueName: "franzi",
+      evidence: [],
+      items: params.items ?? [
+        {
+          type: "message_handler",
+          action: "create",
+          conflict: "missing",
+          reason: "missing",
+          requiresConfirmation: true,
+        },
+      ],
+    },
+    account: { botId: "franzi", webhookSecret: SECRET },
+    publicWebhookUrl: URL_OK,
+    confirmed: params.confirmed ?? true,
+    writer: params.writer ?? writer(),
+  });
+}
+
+describe("applyCliqHandlerProvisioning — consent gate", () => {
+  it("mutates nothing without explicit confirmation", async () => {
+    const w = writer();
+    const result = await apply({ writer: w, confirmed: false });
+    expect(result.applied).toBe(false);
+    expect(w.createHandler).not.toHaveBeenCalled();
+    expect(w.updateHandler).not.toHaveBeenCalled();
+    expect(result.results[0].outcome).toBe("skipped_unconfirmed");
+  });
+
+  it("never mutates a handler whose state could not be read", async () => {
+    const w = writer();
+    const result = await apply({
+      writer: w,
+      items: [
+        {
+          type: "mention_handler",
+          action: "blocked",
+          conflict: "unreadable",
+          reason: "unreadable",
+          requiresConfirmation: false,
+        },
+      ],
+    });
+    expect(w.createHandler).not.toHaveBeenCalled();
+    expect(w.updateHandler).not.toHaveBeenCalled();
+    expect(result.results[0].outcome).toBe("skipped_blocked");
+  });
+});
+
+describe("applyCliqHandlerProvisioning — create and fallback", () => {
+  it("creates a missing handler directly when Zoho accepts the full script", async () => {
+    const w = writer();
+    const result = await apply({ writer: w });
+    expect(w.createHandler).toHaveBeenCalledTimes(1);
+    expect(w.updateHandler).not.toHaveBeenCalled();
+    expect(result.results[0].outcome).toBe("created");
+    const [type, botId, script] = (w.createHandler as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(type).toBe("message_handler");
+    expect(botId).toBe(BOT_ID);
+    expect(script).toContain('payload.put("handler", "message")');
+  });
+
+  it("falls back to minimal-create-then-PATCH on the known generic create failure", async () => {
+    const w = writer({
+      createHandler: vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, code: "operation_failed" })
+        .mockResolvedValueOnce({ ok: true }),
+    });
+    const result = await apply({ writer: w });
+    expect(w.createHandler).toHaveBeenCalledTimes(2);
+    const minimal = (w.createHandler as ReturnType<typeof vi.fn>).mock.calls[1][2] as string;
+    const full = (w.createHandler as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
+    expect(minimal.length).toBeLessThan(full.length);
+    expect(w.updateHandler).toHaveBeenCalledTimes(1);
+    expect(result.results[0].outcome).toBe("created_via_patch_fallback");
+    // The fallback must stay observable rather than looking like a plain create.
+    expect(result.results[0].detail).toMatch(/fallback/i);
+  });
+
+  it("does not use the fallback for an unrelated create failure", async () => {
+    const w = writer({
+      createHandler: vi.fn(async () => ({ ok: false as const, code: "invalid_oauth_scope" })),
+    });
+    const result = await apply({ writer: w });
+    expect(w.createHandler).toHaveBeenCalledTimes(1);
+    expect(w.updateHandler).not.toHaveBeenCalled();
+    expect(result.results[0].outcome).toBe("failed");
+  });
+
+  it("repairs a diverging handler with PATCH rather than a create", async () => {
+    const w = writer();
+    const result = await apply({
+      writer: w,
+      items: [
+        {
+          type: "mention_handler",
+          action: "repair",
+          conflict: "secret_mismatch",
+          reason: "secret differs",
+          requiresConfirmation: true,
+        },
+      ],
+    });
+    expect(w.createHandler).not.toHaveBeenCalled();
+    expect(w.updateHandler).toHaveBeenCalledTimes(1);
+    const script = (w.updateHandler as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
+    expect(script).not.toContain("attachments");
+    expect(result.results[0].outcome).toBe("repaired");
+  });
+});
+
+describe("applyCliqHandlerProvisioning — verification and redaction", () => {
+  it("reads the handler back and fails when Zoho did not store the intended values", async () => {
+    const w = writer({
+      readHandlerScript: vi.fn(async () => ({
+        script: `webhookUrl = "${URL_OK}";\nwebhookSecret = "something-else";`,
+      })),
+    });
+    const result = await apply({ writer: w });
+    expect(w.readHandlerScript).toHaveBeenCalled();
+    expect(result.results[0].verified).toBe(false);
+    expect(result.ok).toBe(false);
+  });
+
+  it("confirms the read-back when the stored handler matches", async () => {
+    const result = await apply();
+    expect(result.results[0].verified).toBe(true);
+    expect(result.ok).toBe(true);
+  });
+
+  it("keeps the secret and script out of every reported string", async () => {
+    const w = writer({
+      createHandler: vi.fn(async () => ({
+        ok: false as const,
+        code: "operation_failed",
+        detail: `raw body: webhookSecret = "${SECRET}"`,
+      })),
+      updateHandler: vi.fn(async () => ({ ok: false as const, code: "execution_handler_update_failed" })),
+    });
+    const result = await apply({ writer: w });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain("raw body");
+  });
+});
+
+describe("isRetryableCliqProvisioningFailure", () => {
+  it("does not treat execution_handler_update_failed as retryable", () => {
+    expect(isRetryableCliqProvisioningFailure("execution_handler_update_failed")).toBe(false);
+  });
+
+  it("surfaces the script-validity explanation for that code", async () => {
+    const w = writer({
+      updateHandler: vi.fn(async () => ({
+        ok: false as const,
+        code: "execution_handler_update_failed",
+      })),
+    });
+    const result = await apply({
+      writer: w,
+      items: [
+        {
+          type: "mention_handler",
+          action: "repair",
+          conflict: "secret_mismatch",
+          reason: "secret differs",
+          requiresConfirmation: true,
+        },
+      ],
+    });
+    expect(result.results[0].outcome).toBe("failed");
+    expect(result.results[0].detail).toMatch(/script/i);
+    expect(result.results[0].retryable).toBe(false);
+  });
+});

--- a/src/bot-provisioning.test.ts
+++ b/src/bot-provisioning.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildCliqHandlerScript,
+  planCliqHandlerProvisioning,
+  type CliqProvisioningReader,
+} from "./bot-provisioning.js";
+
+
+const URL_OK = "https://cliq.example.com/cliq/webhook";
+const SECRET = "config-secret";
+
+function script(secret = SECRET, url = URL_OK, extra = ""): string {
+  return `webhookUrl = "${url}";\nwebhookSecret = "${secret}";\npayload = Map();\n${extra}`;
+}
+
+function reader(overrides: Partial<CliqProvisioningReader> = {}): CliqProvisioningReader {
+  return {
+    listBots: vi.fn(async () => [{ id: "b-464329000000074001", unique_name: "franzi" }]),
+    readHandlerScript: vi.fn(async () => ({ script: script() })),
+    ...overrides,
+  };
+}
+
+function plan(params: {
+  reader?: CliqProvisioningReader;
+  secret?: string;
+  url?: string;
+} = {}) {
+  return planCliqHandlerProvisioning({
+    account: { botId: "franzi", webhookSecret: params.secret ?? SECRET },
+    publicWebhookUrl: params.url ?? URL_OK,
+    reader: params.reader ?? reader(),
+  });
+}
+
+describe("buildCliqHandlerScript", () => {
+  it("emits a message handler that forwards attachments as raw JSON", () => {
+    const body = buildCliqHandlerScript({
+      handlerType: "message_handler",
+      webhookUrl: URL_OK,
+      webhookSecret: SECRET,
+    });
+    expect(body).toContain('payload.put("handler", "message")');
+    expect(body).toContain("attachments");
+    expect(body).toContain("body   : payload.toString()");
+    expect(body).toContain('headers.put("Content-Type", "application/json")');
+    expect(body).not.toContain("parameters");
+  });
+
+  it("omits attachments from the mention handler, which Zoho does not provide", () => {
+    const body = buildCliqHandlerScript({
+      handlerType: "mention_handler",
+      webhookUrl: URL_OK,
+      webhookSecret: SECRET,
+    });
+    expect(body).toContain('payload.put("handler", "mention")');
+    expect(body).not.toContain("attachments");
+  });
+
+  it("never produces byte-identical message and mention scripts", () => {
+    const message = buildCliqHandlerScript({
+      handlerType: "message_handler",
+      webhookUrl: URL_OK,
+      webhookSecret: SECRET,
+    });
+    const mention = buildCliqHandlerScript({
+      handlerType: "mention_handler",
+      webhookUrl: URL_OK,
+      webhookSecret: SECRET,
+    });
+    expect(message).not.toBe(mention);
+  });
+
+  it("emits a welcome handler that forwards the newuser flag", () => {
+    const body = buildCliqHandlerScript({
+      handlerType: "welcome_handler",
+      webhookUrl: URL_OK,
+      webhookSecret: SECRET,
+    });
+    expect(body).toContain('payload.put("handler", "welcome")');
+    expect(body).toContain("newuser");
+    expect(body).not.toContain("attachments");
+  });
+});
+
+describe("planCliqHandlerProvisioning — read-only", () => {
+  it("reports no changes when both handlers already carry the configured URL and secret", async () => {
+    const result = await plan();
+    expect(result.status).toBe("in_sync");
+    expect(result.botId).toBe("b-464329000000074001");
+    expect(result.items.map((item) => item.action)).toEqual(["none", "none"]);
+  });
+
+  it("plans a create for a handler Zoho does not have yet", async () => {
+    const result = await plan({
+      reader: reader({
+        readHandlerScript: vi.fn(async (type: string) =>
+          type === "mention_handler"
+            ? { error: "Zoho answered HTTP 404" }
+            : { script: script() },
+        ),
+      }),
+    });
+    expect(result.status).toBe("changes_required");
+    const mention = result.items.find((item) => item.type === "mention_handler")!;
+    expect(mention.action).toBe("create");
+    expect(mention.requiresConfirmation).toBe(true);
+  });
+
+  it("treats a matching URL with a diverging secret as a first-class conflict, not 'already configured'", async () => {
+    const result = await plan({
+      reader: reader({
+        readHandlerScript: vi.fn(async () => ({ script: script("stale-host-secret", URL_OK) })),
+      }),
+    });
+    expect(result.status).toBe("conflict");
+    for (const item of result.items) {
+      expect(item.action).toBe("repair");
+      expect(item.conflict).toBe("secret_mismatch");
+      expect(item.requiresConfirmation).toBe(true);
+      expect(item.reason).toMatch(/secret/i);
+    }
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("stale-host-secret");
+    expect(serialized).not.toContain(SECRET);
+  });
+
+  it("reports a diverging webhook URL as its own conflict", async () => {
+    const result = await plan({
+      reader: reader({
+        readHandlerScript: vi.fn(async () => ({
+          script: script(SECRET, "https://old-host.example.com/cliq/webhook"),
+        })),
+      }),
+    });
+    expect(result.status).toBe("conflict");
+    expect(result.items[0].conflict).toBe("url_mismatch");
+  });
+
+  it("never plans a silent overwrite of an unrecognised hand-written handler", async () => {
+    const result = await plan({
+      reader: reader({
+        readHandlerScript: vi.fn(async () => ({
+          script: "secret = zoho.vault.get(\"cliq\");\ninvokeUrl[];",
+        })),
+      }),
+    });
+    expect(result.status).toBe("conflict");
+    expect(result.items[0].conflict).toBe("unrecognised_script");
+    expect(result.items[0].requiresConfirmation).toBe(true);
+  });
+
+  it("blocks instead of guessing when the handler cannot be read at all", async () => {
+    const result = await plan({
+      reader: reader({
+        readHandlerScript: vi.fn(async () => ({
+          error: "Zoho refused the read with HTTP 403",
+        })),
+      }),
+    });
+    expect(result.status).toBe("blocked");
+    expect(result.items[0].action).toBe("blocked");
+    expect(result.items[0].conflict).toBe("unreadable");
+  });
+
+  it("blocks when the configured bot cannot be resolved to an internal id", async () => {
+    const result = await plan({ reader: reader({ listBots: vi.fn(async () => []) }) });
+    expect(result.status).toBe("blocked");
+    expect(result.botId).toBeUndefined();
+    expect(result.evidence.join(" ")).toMatch(/unique name/i);
+  });
+
+  it("blocks when no webhook secret or public URL is configured rather than writing an empty one", async () => {
+    const noSecret = await plan({ secret: "" });
+    expect(noSecret.status).toBe("blocked");
+    const noUrl = await plan({ url: "" });
+    expect(noUrl.status).toBe("blocked");
+  });
+
+  it("never reads a handler with the configured unique name instead of the internal id", async () => {
+    const readHandlerScript = vi.fn(
+      async (_type: string, _botId?: string) => ({ script: script() }),
+    );
+    await plan({ reader: reader({ readHandlerScript }) });
+    for (const call of readHandlerScript.mock.calls) {
+      expect(call[1]).toBe("b-464329000000074001");
+    }
+  });
+
+  it("keeps handler bodies, secrets, and tokens out of the plan evidence", async () => {
+    const leaked = 'webhookSecret = "live-secret"; access_token = "tok-123";';
+    const result = await plan({
+      reader: reader({
+        readHandlerScript: vi.fn(async () => ({ script: leaked })),
+      }),
+    });
+    const serialized = JSON.stringify(result);    expect(serialized).not.toContain("live-secret");
+    expect(serialized).not.toContain("tok-123");
+    expect(serialized).not.toContain(leaked);
+  });
+});
+
+describe("planCliqHandlerProvisioning — optional welcome handler", () => {
+  it("ignores the welcome handler unless it is explicitly requested", async () => {
+    const result = await planCliqHandlerProvisioning({
+      account: { botId: "franzi", webhookSecret: SECRET },
+      publicWebhookUrl: URL_OK,
+      reader: reader(),
+    });
+    expect(result.items.map((item) => item.type)).toEqual([
+      "message_handler",
+      "mention_handler",
+    ]);
+  });
+
+  it("plans the welcome handler when the greeting is opted in", async () => {
+    const result = await planCliqHandlerProvisioning({
+      account: { botId: "franzi", webhookSecret: SECRET },
+      publicWebhookUrl: URL_OK,
+      includeWelcome: true,
+      reader: reader({
+        readHandlerScript: vi.fn(async (type: string) =>
+          type === "welcome_handler"
+            ? { error: "Zoho answered HTTP 404" }
+            : { script: script() },
+        ),
+      }),
+    });
+    const welcome = result.items.find((item) => item.type === "welcome_handler")!;
+    expect(welcome.action).toBe("create");
+    expect(result.status).toBe("changes_required");
+  });
+});

--- a/src/bot-provisioning.ts
+++ b/src/bot-provisioning.ts
@@ -1,0 +1,505 @@
+import { resolveCliqInternalBotId, type CliqBotIdLister } from "./bot-id.js";
+import {
+  CLIQ_INBOUND_HANDLER_TYPES,
+  extractDelugeStringAssignment,
+  fingerprintCliqSecret,
+  type CliqInboundHandlerType,
+} from "./handler-consistency.js";
+
+/**
+ * Idempotent bot/handler provisioning (issue #94).
+ *
+ * The planning half is deliberately **read-only**: it resolves the configured
+ * unique name through the shared resolver (`src/bot-id.ts`, issue #149), reads
+ * each handler back, and classifies what a mutation *would* have to do. No
+ * request in this module changes Zoho state.
+ *
+ * Two rules come from live rollouts and are encoded as types, not comments:
+ *
+ * - **A matching unique name is not proof of ownership.** "Bot exists,
+ *   handlers exist, URL matches, secret does NOT" is its own conflict
+ *   (`secret_mismatch`), never "already configured, nothing to do" — that
+ *   exact state shipped a deployment whose real inbound would have been 401
+ *   while the preflight was green.
+ * - **Absence of evidence is never consent.** An unreadable or unrecognised
+ *   handler is `blocked` / `unrecognised_script`, so a hand-written handler is
+ *   never silently overwritten.
+ *
+ * Every string this module produces is fingerprint-only: handler bodies, the
+ * configured secret, and OAuth material never reach the plan (#113).
+ */
+
+export type CliqProvisionedHandlerType = CliqInboundHandlerType | "welcome_handler";
+
+export type CliqHandlerPlanAction = "none" | "create" | "repair" | "blocked";
+
+export type CliqHandlerPlanConflict =
+  | "secret_mismatch"
+  | "url_mismatch"
+  | "unrecognised_script"
+  | "unreadable"
+  | "missing";
+
+export type CliqProvisioningStatus =
+  | "in_sync"
+  | "changes_required"
+  | "conflict"
+  | "blocked";
+
+export interface CliqHandlerPlanItem {
+  type: CliqProvisionedHandlerType;
+  action: CliqHandlerPlanAction;
+  conflict?: CliqHandlerPlanConflict;
+  /** Redacted, human-readable justification. Never contains a secret. */
+  reason: string;
+  /** True when applying this item would mutate Zoho-held state. */
+  requiresConfirmation: boolean;
+}
+
+export interface CliqProvisioningPlan {
+  status: CliqProvisioningStatus;
+  botId?: string;
+  configuredUniqueName: string;
+  items: CliqHandlerPlanItem[];
+  /** Redacted lines suitable for CLI output and JSON reports. */
+  evidence: string[];
+}
+
+export interface CliqProvisioningReader {
+  listBots: CliqBotIdLister;
+  readHandlerScript(
+    handlerType: string,
+    botId?: string,
+  ): Promise<{ script?: string; error?: string }>;
+}
+
+/**
+ * Render the Deluge handler script for one inbound handler type.
+ *
+ * The Message and Mention scripts must NOT be byte-identical: the Mention
+ * Handler does not receive the `attachments` parameter, and a Mention script
+ * that references it fails Zoho's validation with
+ * `execution_handler_update_failed` — a script-validity fault, not a
+ * transient error. The payload is posted with `body:` (raw JSON) rather than
+ * `parameters:`, which would form-encode it and break the webhook.
+ */
+export function buildCliqHandlerScript(params: {
+  handlerType: CliqProvisionedHandlerType;
+  webhookUrl: string;
+  webhookSecret: string;
+}): string {
+  const discriminator = params.handlerType === "message_handler"
+    ? "message"
+    : params.handlerType === "mention_handler"
+      ? "mention"
+      : "welcome";
+  if (params.handlerType === "welcome_handler") {
+    return [
+      `webhookUrl = "${params.webhookUrl}";`,
+      `webhookSecret = "${params.webhookSecret}";`,
+      "",
+      "payload = Map();",
+      'payload.put("handler", "welcome");',
+      'payload.put("user", user);',
+      'payload.put("newuser", newuser);',
+      "",
+      "headers = Map();",
+      'headers.put("Content-Type", "application/json");',
+      'headers.put("x-cliq-webhook-secret", webhookSecret);',
+      "",
+      "invokeUrl",
+      "[",
+      "    url    : webhookUrl",
+      "    type   : POST",
+      "    body   : payload.toString()",
+      "    headers: headers",
+      "];",
+      "",
+      "response = Map();",
+      "return response;",
+      "",
+    ].join("\n");
+  }
+  const attachments =
+    params.handlerType === "message_handler"
+      ? 'if (attachments != null)\n{\n    payload.put("attachments", attachments);\n}\n'
+      : "";
+  return [
+    `webhookUrl = "${params.webhookUrl}";`,
+    `webhookSecret = "${params.webhookSecret}";`,
+    "",
+    "payload = Map();",
+    `payload.put("handler", "${discriminator}");`,
+    'payload.put("message", message);',
+    'payload.put("user", user);',
+    'payload.put("chat", chat);',
+    attachments,
+    "headers = Map();",
+    'headers.put("Content-Type", "application/json");',
+    'headers.put("x-cliq-webhook-secret", webhookSecret);',
+    "",
+    "invokeUrl",
+    "[",
+    "    url    : webhookUrl",
+    "    type   : POST",
+    "    body   : payload.toString()",
+    "    headers: headers",
+    "];",
+    "",
+    "response = Map();",
+    "return response;",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Zoho's generic create failure. Live rollouts showed the Message Handler
+ * accepting a full script while the Mention Handler answered `operation_failed`
+ * for the same strategy; creating a minimal handler and then `PATCH`ing the
+ * real script succeeded immediately. The fallback is deliberately keyed to
+ * this one code so an unrelated failure (a scope problem, say) is reported
+ * rather than retried through a different path.
+ */
+const CLIQ_GENERIC_CREATE_FAILURE = "operation_failed";
+
+/**
+ * `execution_handler_update_failed` is NOT reliably transient: the Mention
+ * Handler does not expose `attachments`, so a script referencing it fails
+ * validation on every attempt. Retrying alone never fixes it.
+ */
+const CLIQ_SCRIPT_VALIDITY_FAILURE = "execution_handler_update_failed";
+
+export function isRetryableCliqProvisioningFailure(code: string | undefined): boolean {
+  if (!code) return false;
+  if (code === CLIQ_SCRIPT_VALIDITY_FAILURE) return false;
+  return /timeout|rate_limit|temporarily|internal_error/i.test(code);
+}
+
+export type CliqHandlerApplyOutcome =
+  | "created"
+  | "created_via_patch_fallback"
+  | "repaired"
+  | "failed"
+  | "skipped_unconfirmed"
+  | "skipped_blocked"
+  | "skipped_in_sync";
+
+export interface CliqHandlerApplyResult {
+  type: CliqProvisionedHandlerType;
+  outcome: CliqHandlerApplyOutcome;
+  /** Redacted explanation. Never contains a script body or secret. */
+  detail: string;
+  /** Whether the handler was read back and matched the intended values. */
+  verified?: boolean;
+  retryable?: boolean;
+}
+
+export interface CliqProvisioningApplyReport {
+  ok: boolean;
+  applied: boolean;
+  results: CliqHandlerApplyResult[];
+}
+
+export interface CliqProvisioningWriter {
+  createHandler(
+    handlerType: string,
+    botId: string,
+    script: string,
+  ): Promise<{ ok: boolean; code?: string; detail?: string }>;
+  updateHandler(
+    handlerType: string,
+    botId: string,
+    script: string,
+  ): Promise<{ ok: boolean; code?: string; detail?: string }>;
+  readHandlerScript(
+    handlerType: string,
+    botId?: string,
+  ): Promise<{ script?: string; error?: string }>;
+}
+
+/** A syntactically valid placeholder used only by the create-then-PATCH fallback. */
+function minimalHandlerScript(): string {
+  return ["response = Map();", "return response;", ""].join("\n");
+}
+
+function sameWebhookUrl(a: string, b: string): boolean {
+  const normalize = (raw: string): string => {
+    try {
+      const url = new URL(raw);
+      return `${url.protocol}//${url.host.toLowerCase()}${url.pathname.replace(/\/+$/, "")}`;
+    } catch {
+      return raw.trim().replace(/\/+$/, "");
+    }
+  };
+  return normalize(a) === normalize(b);
+}
+
+function label(type: string): string {
+  return type.replace(/_/g, " ");
+}
+
+function classifyHandler(params: {
+  type: CliqProvisionedHandlerType;  read: { script?: string; error?: string };
+  configSecret: string;
+  expectedUrl: string;
+}): CliqHandlerPlanItem {
+  const name = label(params.type);
+  const { read } = params;
+  if (read.error || typeof read.script !== "string" || read.script.length === 0) {
+    // A 404 is the one read failure that genuinely means "not provisioned";
+    // every other failure leaves the handler state unknown, and unknown must
+    // never authorise a write.
+    const missing = /404|not[ _]found/i.test(read.error ?? "");
+    return missing
+      ? {
+          type: params.type,
+          action: "create",
+          conflict: "missing",
+          reason: `${name} does not exist on the bot and would be created`,
+          requiresConfirmation: true,
+        }
+      : {
+          type: params.type,
+          action: "blocked",
+          conflict: "unreadable",
+          reason: `${name} could not be read (${read.error ?? "no script body was returned"}), so its state is unknown and no change is proposed`,
+          requiresConfirmation: false,
+        };
+  }
+  const handlerUrl = extractDelugeStringAssignment(read.script, "webhookUrl");
+  const handlerSecret = extractDelugeStringAssignment(read.script, "webhookSecret");
+  if (handlerUrl === null || handlerSecret === null) {
+    return {
+      type: params.type,
+      action: "repair",
+      conflict: "unrecognised_script",
+      reason: `${name} does not declare recognisable webhookUrl/webhookSecret literals, so it looks hand-written and is never replaced without explicit confirmation`,
+      requiresConfirmation: true,
+    };
+  }
+  if (!sameWebhookUrl(handlerUrl, params.expectedUrl)) {
+    return {
+      type: params.type,
+      action: "repair",
+      conflict: "url_mismatch",
+      reason: `${name} posts to a different webhook URL than the configured publicWebhookUrl`,
+      requiresConfirmation: true,
+    };
+  }
+  if (handlerSecret !== params.configSecret) {
+    // The exact state observed on a real rollout: the bot and handlers looked
+    // correct and the URL matched, but Zoho held a different secret, so every
+    // real inbound message would have been rejected with 401.
+    return {
+      type: params.type,
+      action: "repair",
+      conflict: "secret_mismatch",
+      reason: `${name} carries a webhook secret that differs from the configured one (handler ${fingerprintCliqSecret(handlerSecret)} vs config ${fingerprintCliqSecret(params.configSecret)}); a matching URL is not proof this handler belongs to this deployment`,
+      requiresConfirmation: true,
+    };
+  }
+  return {
+    type: params.type,
+    action: "none",
+    reason: `${name} already posts to the configured URL with the configured secret`,
+    requiresConfirmation: false,
+  };
+}
+
+function blocked(
+  configuredUniqueName: string,
+  evidence: string[],
+  botId?: string,
+): CliqProvisioningPlan {
+  return { status: "blocked", botId, configuredUniqueName, items: [], evidence };
+}
+
+/**
+ * Produce a read-only provisioning plan. Performs no mutation and returns
+ * only redacted evidence; applying a plan is a separate, confirmation-gated
+ * step.
+ */
+export async function planCliqHandlerProvisioning(params: {
+  account: { botId: string; webhookSecret?: string };
+  publicWebhookUrl?: string;
+  reader: CliqProvisioningReader;
+  includeWelcome?: boolean;
+}): Promise<CliqProvisioningPlan> {
+  const configuredUniqueName = params.account.botId.trim();
+  const configSecret = params.account.webhookSecret?.trim() ?? "";
+  const expectedUrl = params.publicWebhookUrl?.trim() ?? "";
+  if (!configSecret) {
+    return blocked(configuredUniqueName, [
+      "no webhookSecret is configured, so there is no value to provision into the Zoho handlers",
+    ]);
+  }
+  if (!expectedUrl) {
+    return blocked(configuredUniqueName, [
+      "no publicWebhookUrl is configured, so the handler target URL is unknown",
+    ]);
+  }
+  const resolved = await resolveCliqInternalBotId({
+    configuredId: configuredUniqueName,
+    listBots: params.reader.listBots,
+  });
+  if (!resolved.ok) {
+    return blocked(configuredUniqueName, [resolved.reason]);
+  }
+  const items: CliqHandlerPlanItem[] = [];
+  const handlerTypes: CliqProvisionedHandlerType[] = [
+    ...CLIQ_INBOUND_HANDLER_TYPES,
+    ...(params.includeWelcome ? (["welcome_handler"] as const) : []),
+  ];
+  for (const type of handlerTypes) {
+    let read: { script?: string; error?: string };
+    try {
+      read = await params.reader.readHandlerScript(type, resolved.botId);
+    } catch {
+      read = { error: "the handler read threw an unexpected error" };
+    }
+    items.push(classifyHandler({ type, read, configSecret, expectedUrl }));
+  }
+  const status: CliqProvisioningStatus = items.some((item) => item.action === "blocked")
+    ? "blocked"
+    : items.some((item) => item.conflict && item.conflict !== "missing")
+      ? "conflict"
+      : items.some((item) => item.action !== "none")
+        ? "changes_required"
+        : "in_sync";
+  return {
+    status,
+    botId: resolved.botId,
+    configuredUniqueName,
+    items,
+    evidence: items.map((item) => `${item.type}: ${item.reason}`),
+  };
+}
+
+/**
+ * Apply a plan. Mutates Zoho only for items that need it AND only when the
+ * caller passes explicit confirmation; a `blocked` item is never written,
+ * because unknown handler state must not authorise an overwrite. Every
+ * mutation is followed by a read-back so success means "Zoho stored what we
+ * intended", not merely "the API returned 2xx".
+ */
+export async function applyCliqHandlerProvisioning(params: {
+  plan: CliqProvisioningPlan;
+  account: { botId: string; webhookSecret?: string };
+  publicWebhookUrl?: string;
+  confirmed: boolean;
+  writer: CliqProvisioningWriter;
+}): Promise<CliqProvisioningApplyReport> {
+  const botId = params.plan.botId;
+  const secret = params.account.webhookSecret?.trim() ?? "";
+  const url = params.publicWebhookUrl?.trim() ?? "";
+  const results: CliqHandlerApplyResult[] = [];
+  let applied = false;
+
+  for (const item of params.plan.items) {
+    if (item.action === "none") {
+      results.push({
+        type: item.type,
+        outcome: "skipped_in_sync",
+        detail: `${label(item.type)} already matches the configured URL and secret`,
+      });
+      continue;
+    }
+    if (item.action === "blocked") {
+      results.push({
+        type: item.type,
+        outcome: "skipped_blocked",
+        detail: `${label(item.type)} was not changed because its current state could not be read`,
+      });
+      continue;
+    }
+    if (!params.confirmed) {
+      results.push({
+        type: item.type,
+        outcome: "skipped_unconfirmed",
+        detail: `${label(item.type)} needs an explicit confirmation before Zoho-held code is changed`,
+      });
+      continue;
+    }
+    if (!botId || !secret || !url) {
+      results.push({
+        type: item.type,
+        outcome: "failed",
+        detail: `${label(item.type)} could not be provisioned because the bot id, secret, or public URL was unavailable`,
+        retryable: false,
+      });
+      continue;
+    }
+
+    const script = buildCliqHandlerScript({
+      handlerType: item.type,
+      webhookUrl: url,
+      webhookSecret: secret,
+    });
+    let outcome: CliqHandlerApplyOutcome | undefined;
+    let failureCode: string | undefined;
+
+    if (item.action === "create") {
+      const created = await params.writer.createHandler(item.type, botId, script);
+      if (created.ok) {
+        outcome = "created";
+      } else if (created.code === CLIQ_GENERIC_CREATE_FAILURE) {
+        // Known Zoho behaviour: full-script create can fail generically while
+        // minimal-create followed by PATCH succeeds.
+        const minimal = await params.writer.createHandler(item.type, botId, minimalHandlerScript());
+        if (minimal.ok) {
+          const patched = await params.writer.updateHandler(item.type, botId, script);
+          if (patched.ok) outcome = "created_via_patch_fallback";
+          else failureCode = patched.code;
+        } else {
+          failureCode = minimal.code;
+        }
+      } else {
+        failureCode = created.code;
+      }
+    } else {
+      const patched = await params.writer.updateHandler(item.type, botId, script);
+      if (patched.ok) outcome = "repaired";
+      else failureCode = patched.code;
+    }
+
+    if (!outcome) {
+      const scriptValidity = failureCode === CLIQ_SCRIPT_VALIDITY_FAILURE;
+      results.push({
+        type: item.type,
+        outcome: "failed",
+        detail: scriptValidity
+          ? `${label(item.type)} was rejected with ${CLIQ_SCRIPT_VALIDITY_FAILURE}; this usually means the script references a parameter this handler does not receive, so it is a script-validity fault rather than a transient error`
+          : `${label(item.type)} could not be provisioned (Zoho reported ${failureCode ?? "an unspecified failure"})`,
+        retryable: isRetryableCliqProvisioningFailure(failureCode),
+      });
+      continue;
+    }
+
+    applied = true;
+    const readBack = await params.writer.readHandlerScript(item.type, botId);
+    const storedUrl = readBack.script
+      ? extractDelugeStringAssignment(readBack.script, "webhookUrl")
+      : null;
+    const storedSecret = readBack.script
+      ? extractDelugeStringAssignment(readBack.script, "webhookSecret")
+      : null;
+    const verified =
+      storedUrl !== null &&
+      storedSecret !== null &&
+      sameWebhookUrl(storedUrl, url) &&
+      storedSecret === secret;
+    results.push({
+      type: item.type,
+      outcome,
+      detail: verified
+        ? `${label(item.type)} was ${outcome === "created_via_patch_fallback" ? "created through the minimal-create-then-PATCH fallback" : outcome} and read back with the configured URL and secret`
+        : `${label(item.type)} was written but the read-back did not match the configured URL and secret`,
+      verified,
+    });
+  }
+
+  const ok = results.every(
+    (result) => result.outcome !== "failed" && result.verified !== false,
+  );
+  return { ok, applied, results };
+}

--- a/src/client-bot-provisioning.test.ts
+++ b/src/client-bot-provisioning.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { CliqClient } from "./client.js";
+
+interface CapturedRequest {
+  url: URL;
+  method: string;
+  body?: string;
+}
+
+function installFetch(
+  handler: (request: CapturedRequest, call: number) => Response,
+): { requests: CapturedRequest[]; restore: () => void } {
+  const original = globalThis.fetch;
+  const requests: CapturedRequest[] = [];
+  let call = 0;
+  globalThis.fetch = (async (input: URL | string, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : input.toString());
+    if (url.pathname === "/oauth/v2/token") {
+      return new Response(JSON.stringify({ access_token: "token", expires_in: 3600 }), {
+        status: 200,
+      });
+    }
+    const request = {
+      url,
+      method: init?.method ?? "GET",
+      body: typeof init?.body === "string" ? init.body : undefined,
+    };
+    requests.push(request);
+    call++;
+    return handler(request, call);
+  }) as typeof fetch;
+  return { requests, restore: () => { globalThis.fetch = original; } };
+}
+
+afterEach(() => {
+  globalThis.fetch = globalThis.fetch;
+});
+
+describe("CliqClient bot/handler provisioning API", () => {
+  it("creates an organization bot without sending a unique_name", async () => {
+    const mock = installFetch(() => new Response(JSON.stringify({
+      data: { id: "b-1", unique_name: "franzi", name: "Franzi" },
+    }), { status: 201 }));
+    const client = new CliqClient("id", "secret", "franzi");
+    try {
+      const result = await client.createBot("Franzi");
+      expect(result).toEqual({
+        ok: true,
+        bot: { id: "b-1", unique_name: "franzi", name: "Franzi" },
+      });
+    } finally {
+      mock.restore();
+    }
+    expect(mock.requests[0].url.pathname).toBe("/api/v3/bots");
+    expect(mock.requests[0].method).toBe("POST");
+    expect(JSON.parse(mock.requests[0].body!)).toEqual({
+      name: "Franzi",
+      scope: "organization",
+    });
+    expect(mock.requests[0].body).not.toContain("unique_name");
+  });
+
+  it("creates a handler through the collection route with type and script", async () => {
+    const mock = installFetch(() => new Response("{}", { status: 201 }));
+    const client = new CliqClient("id", "secret", "franzi");
+    try {
+      expect(await client.createBotHandler("b-1", "message_handler", "handler body")).toEqual({ ok: true });
+    } finally {
+      mock.restore();
+    }
+    expect(mock.requests[0].url.pathname).toBe("/api/v3/bots/b-1/handlers");
+    expect(mock.requests[0].method).toBe("POST");
+    expect(JSON.parse(mock.requests[0].body!)).toEqual({ type: "message_handler", script: "handler body" });
+  });
+
+  it("updates a handler through PATCH with a script-only body", async () => {
+    const mock = installFetch(() => new Response("{}", { status: 200 }));
+    const client = new CliqClient("id", "secret", "franzi");
+    try {
+      expect(await client.updateBotHandler("b-1", "mention_handler", "handler body")).toEqual({ ok: true });
+    } finally {
+      mock.restore();
+    }
+    expect(mock.requests[0].url.pathname).toBe("/api/v3/bots/b-1/handlers/mention_handler");
+    expect(mock.requests[0].method).toBe("PATCH");
+    expect(JSON.parse(mock.requests[0].body!)).toEqual({ script: "handler body" });
+  });
+
+  it("returns the Zoho error code without exposing its raw body", async () => {
+    const leaked = 'webhookSecret = "live-secret"; access_token = "tok";';
+    const mock = installFetch(() => new Response(JSON.stringify({
+      code: "operation_failed",
+      message: leaked,
+    }), { status: 400 }));
+    const client = new CliqClient("id", "secret", "franzi");
+    let result;
+    try {
+      result = await client.createBotHandler("b-1", "mention_handler", "handler body");
+    } finally {
+      mock.restore();
+    }
+    expect(result).toEqual({ ok: false, code: "operation_failed", status: 400 });
+    expect(JSON.stringify(result)).not.toContain("live-secret");
+    expect(JSON.stringify(result)).not.toContain("tok");
+  });
+
+  it("classifies a missing update scope without returning OAuth response content", async () => {
+    const mock = installFetch(() => new Response(JSON.stringify({
+      code: "oauthtoken_scope_invalid",
+      message: "raw sensitive response",
+    }), { status: 401 }));
+    const client = new CliqClient("id", "secret", "franzi");
+    let result;
+    try {
+      result = await client.updateBotHandler("b-1", "message_handler", "handler body");
+    } finally {
+      mock.restore();
+    }
+    expect(result).toEqual({ ok: false, code: "missing_scope", status: 401 });
+    expect(JSON.stringify(result)).not.toContain("raw sensitive response");
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -2436,6 +2436,49 @@ export class CliqClient {
     return res.json();
   }
 
+  private async writeBotJson(
+    path: string,
+    method: "POST" | "PATCH",
+    body: unknown,
+    scope = "ZohoCliq.Bots.UPDATE",
+  ): Promise<{ ok: true; data: unknown } | { ok: false; code: string; status?: number }> {
+    let token: string;
+    try {
+      token = await this.getAccessToken(scope);
+    } catch {
+      return { ok: false, code: "missing_scope" };
+    }
+    let response: Response;
+    try {
+      response = await fetch(`${this.apiBase}${path}`, {
+        method,
+        headers: {
+          Authorization: `Zoho-oauthtoken ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      return { ok: false, code: "transport" };
+    }
+    let data: unknown = null;
+    try {
+      data = await response.json();
+    } catch {
+      data = null;
+    }
+    if (response.ok) return { ok: true, data };
+    const returnedCode =
+      data && typeof data === "object" && typeof (data as { code?: unknown }).code === "string"
+        ? (data as { code: string }).code
+        : "";
+    const code =
+      response.status === 401 || returnedCode.toLowerCase().includes("scope")
+        ? "missing_scope"
+        : returnedCode || (response.status === 403 ? "missing_scope" : "http_error");
+    return { ok: false, code, status: response.status };
+  }
+
   private async readBotJson(path: string): Promise<unknown | CliqBotReadFailure> {
     let token: string;
     try {
@@ -2491,6 +2534,51 @@ export class CliqClient {
       return { kind: "not_found", detail: "Zoho reported that the bot was not found", status: res.status };
     }
     return { kind: "http", detail: `Zoho answered HTTP ${res.status}`, status: res.status };
+  }
+
+  async createBot(name: string): Promise<
+    | { ok: true; bot: CliqBotRecord }
+    | { ok: false; code: string; status?: number }
+  > {
+    return this.writeBotJson("/api/v3/bots", "POST", {
+      name,
+      scope: "organization",
+    }, "ZohoCliq.Bots.CREATE").then((result) => {
+      if (!result.ok) return result;
+      const value = result.data as { data?: unknown } | unknown;
+      const bot = (value && typeof value === "object" && !Array.isArray(value) && "data" in value)
+        ? (value as { data: unknown }).data
+        : value;
+      return bot && typeof bot === "object" && !Array.isArray(bot)
+        ? { ok: true as const, bot: bot as CliqBotRecord }
+        : { ok: false as const, code: "invalid_response" };
+    });
+  }
+
+  async createBotHandler(
+    botId: string,
+    handlerType: string,
+    script: string,
+  ): Promise<{ ok: boolean; code?: string; status?: number }> {
+    const result = await this.writeBotJson(
+      `/api/v3/bots/${encodeURIComponent(botId)}/handlers`,
+      "POST",
+      { type: handlerType, script },
+    );
+    return result.ok ? { ok: true } : result;
+  }
+
+  async updateBotHandler(
+    botId: string,
+    handlerType: string,
+    script: string,
+  ): Promise<{ ok: boolean; code?: string; status?: number }> {
+    const result = await this.writeBotJson(
+      `/api/v3/bots/${encodeURIComponent(botId)}/handlers/${encodeURIComponent(handlerType)}`,
+      "PATCH",
+      { script },
+    );
+    return result.ok ? { ok: true } : result;
   }
 
   async listBots(maxItems = 5_000): Promise<CliqBotRecord[] | CliqBotReadFailure> {

--- a/src/setup-provisioning-flow.test.ts
+++ b/src/setup-provisioning-flow.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  runCliqSetupProvisioning,
+  type CliqSetupProvisioningDeps,
+} from "./setup-provisioning-flow.js";
+import type { CliqProvisioningRunResult } from "./setup-provisioning.js";
+
+const URL_OK = "https://cliq.example.com/cliq/webhook";
+const SECRET = "config-secret";
+
+function result(status: CliqProvisioningRunResult["plan"]["status"]): CliqProvisioningRunResult {
+  return {
+    createdBot: false,
+    plan: {
+      status,
+      botId: "b-1",
+      configuredUniqueName: "franzi",
+      evidence: [
+        status === "conflict"
+          ? "message_handler: secret differs (handler sha256:aaa vs config sha256:bbb)"
+          : "message_handler: already configured",
+      ],
+      items: status === "conflict"
+        ? [{
+            type: "message_handler",
+            action: "repair",
+            conflict: "secret_mismatch",
+            reason: "secret differs",
+            requiresConfirmation: true,
+          }]
+        : [],
+    },
+  };
+}
+
+function deps(runResult: CliqProvisioningRunResult): CliqSetupProvisioningDeps {
+  return {
+    resolveAccount: vi.fn(() => ({
+      accountId: null,
+      clientId: "id",
+      clientSecret: "secret",
+      botId: "franzi",
+      botName: "Franzi",
+      webhookSecret: SECRET,
+      apiBase: "https://cliq.zoho.eu",
+      oauthBase: "https://accounts.zoho.eu",
+    } as never)),
+    resolveClient: vi.fn(() => ({
+      listBots: vi.fn(),
+      createBot: vi.fn(),
+      readBotHandlerScript: vi.fn(),
+      createBotHandler: vi.fn(),
+      updateBotHandler: vi.fn(),
+    } as never)),
+    provision: vi.fn(async () => runResult),
+  };
+}
+
+function prompter(confirmValues: boolean[] = []) {
+  const values = [...confirmValues];
+  return {
+    confirm: vi.fn(async () => values.shift() ?? false),
+    note: vi.fn(async () => undefined),
+  };
+}
+
+describe("runCliqSetupProvisioning", () => {
+  it("always performs and displays a read-only dry-run before offering mutation", async () => {
+    const d = deps(result("in_sync"));
+    const prompt = prompter();
+    const output = await runCliqSetupProvisioning({
+      cfg: {} as never,
+      publicWebhookUrl: URL_OK,
+      prompter: prompt as never,
+      deps: d,
+    });
+    expect(d.provision).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true, confirmed: false }));
+    expect(prompt.note).toHaveBeenCalled();
+    expect(output.plan.status).toBe("in_sync");
+    expect(prompt.confirm).not.toHaveBeenCalled();
+  });
+
+  it("requires a separate explicit confirmation before repairing a secret-mismatch conflict", async () => {
+    const dry = result("conflict");
+    const repaired: CliqProvisioningRunResult = {
+      ...dry,
+      apply: {
+        ok: true,
+        applied: true,
+        results: [{
+          type: "message_handler",
+          outcome: "repaired",
+          detail: "read back with the configured URL and secret",
+          verified: true,
+        }],
+      },
+    };
+    const d = deps(dry);
+    (d.provision as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(dry)
+      .mockResolvedValueOnce(repaired);
+    const prompt = prompter([true]);
+    const output = await runCliqSetupProvisioning({
+      cfg: {} as never,
+      publicWebhookUrl: URL_OK,
+      prompter: prompt as never,
+      deps: d,
+    });
+    expect(prompt.confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: false }));
+    expect(d.provision).toHaveBeenLastCalledWith(expect.objectContaining({ dryRun: false, confirmed: true }));
+    expect(output.apply?.applied).toBe(true);
+  });
+
+  it("leaves Zoho unchanged when the operator declines", async () => {
+    const d = deps(result("conflict"));
+    const prompt = prompter([false]);
+    await runCliqSetupProvisioning({
+      cfg: {} as never,
+      publicWebhookUrl: URL_OK,
+      prompter: prompt as never,
+      deps: d,
+    });
+    expect(d.provision).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose secrets through wizard notes", async () => {
+    const leaked = result("conflict");
+    leaked.plan.evidence = [`webhookSecret=${SECRET}`];
+    const d = deps(leaked);
+    const prompt = prompter([false]);
+    await runCliqSetupProvisioning({
+      cfg: {} as never,
+      publicWebhookUrl: URL_OK,
+      prompter: prompt as never,
+      deps: d,
+    });
+    const notes = JSON.stringify(prompt.note.mock.calls);
+    expect(notes).not.toContain(SECRET);
+  });
+});

--- a/src/setup-provisioning-flow.ts
+++ b/src/setup-provisioning-flow.ts
@@ -1,0 +1,132 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/channel-core";
+import type { WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { resolveCliqConfig, type CliqClient, type ResolvedCliqAccount } from "./client.js";
+import { resolveCliqClient } from "./runtime-api.js";
+import {
+  provisionCliqBotAndHandlers,
+  type CliqProvisioningRunResult,
+} from "./setup-provisioning.js";
+
+export interface CliqSetupProvisioningDeps {
+  resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) => ResolvedCliqAccount;
+  resolveClient: (account: ResolvedCliqAccount) => CliqClient;
+  provision: typeof provisionCliqBotAndHandlers;
+}
+
+const defaultDeps: CliqSetupProvisioningDeps = {
+  resolveAccount: resolveCliqConfig,
+  resolveClient: resolveCliqClient,
+  provision: provisionCliqBotAndHandlers,
+};
+
+function serviceFromClient(client: CliqClient) {
+  return {
+    listBots: (maxItems?: number) => client.listBots(maxItems),
+    createBot: (name: string) => client.createBot(name),
+    readHandlerScript: (type: string, botId?: string) =>
+      client.readBotHandlerScript(type, botId),
+    createHandler: (type: string, botId: string, script: string) =>
+      client.createBotHandler(botId, type, script),
+    updateHandler: (type: string, botId: string, script: string) =>
+      client.updateBotHandler(botId, type, script),
+  };
+}
+
+function safeEvidence(line: string, values: readonly string[]): string {
+  let safe = line;
+  for (const value of values) {
+    if (!value) continue;
+    safe = safe.split(value).join("<redacted>");
+  }
+  return safe.replace(
+    /(webhook[_-]?secret|webhookSecret|access[_-]?token)(\s*(?:[=:]|\bis\b)\s*)[^\s,]+/gi,
+    "$1$2<redacted>",
+  );
+}
+
+function describeRun(result: CliqProvisioningRunResult): string {
+  const lines = [
+    `plan status: ${result.plan.status}`,
+    ...result.plan.evidence,
+  ];
+  if (result.apply) {
+    lines.push(
+      ...result.apply.results.map((item) => `${item.type}: ${item.detail}`),
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Setup integration for the provisioning service. The dry-run always executes
+ * first and is displayed before the mutation question. A conflicting
+ * existing handler — including URL-match/secret-mismatch — therefore cannot
+ * be repaired merely because the operator entered setup; it needs a separate
+ * explicit confirmation whose default is false.
+ */
+export async function runCliqSetupProvisioning(params: {
+  cfg: OpenClawConfig;
+  publicWebhookUrl?: string;
+  prompter: Pick<WizardPrompter, "confirm" | "note">;
+  accountId?: string;
+  /** Provision the optional Welcome handler too (greeting opted in). */
+  includeWelcome?: boolean;
+  deps?: Partial<CliqSetupProvisioningDeps>;
+}): Promise<CliqProvisioningRunResult> {
+  const deps = { ...defaultDeps, ...params.deps };
+  const account = deps.resolveAccount(params.cfg, params.accountId ?? null);
+  const client = deps.resolveClient(account);
+  const service = serviceFromClient(client);
+  const values = [account.webhookSecret, account.clientSecret, account.refreshToken]
+    .filter((value): value is string => typeof value === "string" && value.length > 0);
+
+  const dryRun = await deps.provision({
+    account,
+    publicWebhookUrl: params.publicWebhookUrl,
+    dryRun: true,
+    confirmed: false,
+    includeWelcome: params.includeWelcome,
+    service,
+  });
+  await params.prompter.note(
+    describeRun(dryRun)
+      .split("\n")
+      .map((line) => safeEvidence(line, values))
+      .join("\n"),
+    "Zoho Cliq bot/handler provisioning dry-run",
+  );
+
+  if (dryRun.plan.status === "in_sync" || dryRun.plan.status === "blocked") {
+    return dryRun;
+  }
+  let confirmed = false;
+  try {
+    confirmed = await params.prompter.confirm({
+      message:
+        dryRun.plan.status === "conflict"
+          ? "Replace the divergent Zoho bot handler code shown in the redacted dry-run?"
+          : "Create the missing Zoho Cliq bot/handler resources shown in the dry-run?",
+      initialValue: false,
+    });
+  } catch {
+    return dryRun;
+  }
+  if (!confirmed) return dryRun;
+
+  const applied = await deps.provision({
+    account,
+    publicWebhookUrl: params.publicWebhookUrl,
+    dryRun: false,
+    confirmed: true,
+    includeWelcome: params.includeWelcome,
+    service,
+  });
+  await params.prompter.note(
+    describeRun(applied)
+      .split("\n")
+      .map((line) => safeEvidence(line, values))
+      .join("\n"),
+    "Zoho Cliq bot/handler provisioning",
+  );
+  return applied;
+}

--- a/src/setup-provisioning.test.ts
+++ b/src/setup-provisioning.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  provisionCliqBotAndHandlers,
+  type CliqBotProvisioningService,
+} from "./setup-provisioning.js";
+import type { CliqBotRecord } from "./client.js";
+
+const URL_OK = "https://cliq.example.com/cliq/webhook";
+const SECRET = "config-secret";
+
+function service(overrides: Partial<CliqBotProvisioningService> = {}): CliqBotProvisioningService {
+  return {
+    listBots: vi.fn(async () => [{ id: "b-1", unique_name: "franzi" }]),
+    createBot: vi.fn(async () => ({
+      ok: true as const,
+      bot: { id: "b-1", unique_name: "franzi", name: "Franzi" },
+    })),
+    readHandlerScript: vi.fn(async () => ({
+      script: `webhookUrl = "${URL_OK}";\nwebhookSecret = "${SECRET}";`,
+    })),
+    createHandler: vi.fn(async () => ({ ok: true as const })),
+    updateHandler: vi.fn(async () => ({ ok: true as const })),
+    ...overrides,
+  };
+}
+
+function run(params: {
+  service?: CliqBotProvisioningService;
+  dryRun?: boolean;
+  confirmed?: boolean;
+  botId?: string;
+  botName?: string;
+} = {}) {
+  return provisionCliqBotAndHandlers({
+    account: {
+      botId: params.botId ?? "franzi",
+      botName: params.botName ?? "Franzi",
+      webhookSecret: SECRET,
+    },
+    publicWebhookUrl: URL_OK,
+    dryRun: params.dryRun ?? true,
+    confirmed: params.confirmed ?? false,
+    service: params.service ?? service(),
+  });
+}
+
+describe("provisionCliqBotAndHandlers", () => {
+  it("is read-only in dry-run mode", async () => {
+    const api = service();
+    const result = await run({ service: api, dryRun: true });
+    expect(result.plan.status).toBe("in_sync");
+    expect(result.apply).toBeUndefined();
+    expect(api.createBot).not.toHaveBeenCalled();
+    expect(api.createHandler).not.toHaveBeenCalled();
+    expect(api.updateHandler).not.toHaveBeenCalled();
+  });
+
+  it("creates an absent bot only after explicit confirmation, then plans its missing handlers", async () => {
+    const handlerState = new Map<string, string>();
+    const api = service({
+      listBots: vi.fn(async () => [] as CliqBotRecord[]),
+      createBot: vi.fn(async () => ({
+        ok: true as const,
+        bot: { id: "b-2", unique_name: "franzi", name: "Franzi" },
+      })),
+      readHandlerScript: vi.fn(async (type: string) => {
+        const script = handlerState.get(type);
+        return script ? { script } : { error: "Zoho answered HTTP 404" };
+      }),
+      createHandler: vi.fn(async (type: string, _id: string, script: string) => {
+        handlerState.set(type, script);
+        return { ok: true as const };
+      }),
+    });
+    const result = await run({ service: api, dryRun: false, confirmed: true });
+    expect(api.createBot).toHaveBeenCalledWith("Franzi");
+    expect(api.createHandler).toHaveBeenCalledTimes(2);
+    expect(result.createdBot).toBe(true);
+    expect(result.apply?.ok).toBe(true);
+  });
+
+  it("does not create an absent bot during dry-run", async () => {
+    const api = service({ listBots: vi.fn(async () => []) });
+    const result = await run({ service: api, dryRun: true });
+    expect(api.createBot).not.toHaveBeenCalled();
+    expect(result.plan.status).toBe("changes_required");
+    expect(result.plan.evidence.join(" ")).toMatch(/bot.*created/i);
+  });
+
+  it("does not create an absent bot without confirmation", async () => {
+    const api = service({ listBots: vi.fn(async () => []) });
+    const result = await run({ service: api, dryRun: false, confirmed: false });
+    expect(api.createBot).not.toHaveBeenCalled();
+    expect(result.apply?.applied).toBe(false);
+  });
+
+  it("blocks bot creation when Zoho derives a different unique name", async () => {
+    const api = service({
+      listBots: vi.fn(async () => []),
+      createBot: vi.fn(async () => ({
+        ok: true as const,
+        bot: { id: "b-2", unique_name: "franzi-2", name: "Franzi" },
+      })),
+    });
+    const result = await run({ service: api, dryRun: false, confirmed: true });
+    expect(result.plan.status).toBe("blocked");
+    expect(result.plan.evidence.join(" ")).toMatch(/unique name/i);
+    expect(api.createHandler).not.toHaveBeenCalled();
+  });
+
+  it("preserves secret-mismatch as a conflict and requires confirmation for repair", async () => {
+    const api = service({
+      readHandlerScript: vi.fn(async () => ({
+        script: `webhookUrl = "${URL_OK}";\nwebhookSecret = "stale-secret";`,
+      })),
+    });
+    const result = await run({ service: api, dryRun: false, confirmed: false });
+    expect(result.plan.status).toBe("conflict");
+    expect(result.plan.items.every((item) => item.conflict === "secret_mismatch")).toBe(true);
+    expect(api.updateHandler).not.toHaveBeenCalled();
+    expect(result.apply?.results.every((item) => item.outcome === "skipped_unconfirmed")).toBe(true);
+  });
+});

--- a/src/setup-provisioning.ts
+++ b/src/setup-provisioning.ts
@@ -1,0 +1,165 @@
+import {
+  applyCliqHandlerProvisioning,
+  planCliqHandlerProvisioning,
+  type CliqProvisioningApplyReport,
+  type CliqProvisioningPlan,
+} from "./bot-provisioning.js";
+import type { CliqBotIdLister } from "./bot-id.js";
+import type { CliqBotRecord } from "./client.js";
+
+/**
+ * Setup-facing orchestration for issue #94.
+ *
+ * Composes the read-only planner and the confirmation-gated apply step into
+ * the flow `openclaw setup` needs, and adds the one piece neither half owns:
+ * creating the bot itself when it does not exist yet.
+ *
+ * Ordering matters. Zoho derives a bot's `unique_name` from its display name
+ * rather than accepting one, so a freshly created bot can come back with a
+ * name that does not match `channels.cliq.botId`. Provisioning handlers onto
+ * such a bot would configure something the runtime never addresses, so that
+ * case blocks instead of proceeding.
+ */
+
+export interface CliqBotProvisioningService {
+  listBots: CliqBotIdLister;
+  createBot(
+    name: string,
+  ): Promise<{ ok: true; bot: CliqBotRecord } | { ok: false; code: string; status?: number }>;
+  readHandlerScript(
+    handlerType: string,
+    botId?: string,
+  ): Promise<{ script?: string; error?: string }>;
+  createHandler(
+    handlerType: string,
+    botId: string,
+    script: string,
+  ): Promise<{ ok: boolean; code?: string; detail?: string }>;
+  updateHandler(
+    handlerType: string,
+    botId: string,
+    script: string,
+  ): Promise<{ ok: boolean; code?: string; detail?: string }>;
+}
+
+export interface CliqProvisioningRunResult {
+  plan: CliqProvisioningPlan;
+  apply?: CliqProvisioningApplyReport;
+  createdBot: boolean;
+}
+
+async function botExists(
+  service: CliqBotProvisioningService,
+  uniqueName: string,
+): Promise<boolean> {
+  const listed = await service.listBots();
+  if (!Array.isArray(listed)) return false;
+  return listed.some(
+    (record) => record.unique_name?.trim().toLowerCase() === uniqueName.trim().toLowerCase(),
+  );
+}
+
+export async function provisionCliqBotAndHandlers(params: {
+  account: { botId: string; botName?: string; webhookSecret?: string };
+  publicWebhookUrl?: string;
+  dryRun: boolean;
+  confirmed: boolean;
+  /** Include the optional Welcome handler (only when the greeting is opted in). */
+  includeWelcome?: boolean;
+  service: CliqBotProvisioningService;
+}): Promise<CliqProvisioningRunResult> {
+  const uniqueName = params.account.botId.trim();
+  const mayMutate = !params.dryRun && params.confirmed;
+  let createdBot = false;
+  let createdBotId: string | undefined;
+
+  if (!(await botExists(params.service, uniqueName))) {
+    if (!mayMutate) {
+      // Report the intent without touching Zoho. The handler planner would
+      // only be able to say "the bot could not be resolved", which hides the
+      // actionable fact that the bot itself is what is missing.
+      return {
+        createdBot: false,
+        plan: {
+          status: params.dryRun ? "changes_required" : "blocked",
+          configuredUniqueName: uniqueName,
+          items: [],
+          evidence: [
+            `no bot with unique name "${uniqueName}" exists yet; it would be created before its handlers are provisioned`,
+          ],
+        },
+        apply: params.dryRun
+          ? undefined
+          : { ok: false, applied: false, results: [] },
+      };
+    }
+    const created = await params.service.createBot(
+      params.account.botName?.trim() || uniqueName,
+    );
+    if (!created.ok) {
+      return {
+        createdBot: false,
+        plan: {
+          status: "blocked",
+          configuredUniqueName: uniqueName,
+          items: [],
+          evidence: [`the bot could not be created (Zoho reported ${created.code})`],
+        },
+      };
+    }
+    const derived = created.bot.unique_name?.trim().toLowerCase() ?? "";
+    if (derived !== uniqueName.toLowerCase()) {
+      // Zoho derives unique_name from the display name; a mismatch means the
+      // runtime would address a different bot than the one just created.
+      return {
+        createdBot: true,
+        plan: {
+          status: "blocked",
+          botId: created.bot.id,
+          configuredUniqueName: uniqueName,
+          items: [],
+          evidence: [
+            `Zoho derived the unique name "${derived}" from the bot display name, which does not match the configured "${uniqueName}"; update channels.cliq.botId before provisioning handlers`,
+          ],
+        },
+      };
+    }
+    createdBot = true;
+    createdBotId = created.bot.id;
+  }
+
+  const listBots: CliqBotIdLister = createdBotId
+    ? async (maxItems) => {
+        const listed = await params.service.listBots(maxItems);
+        if (!Array.isArray(listed)) {
+          return [{ id: createdBotId, unique_name: uniqueName }];
+        }
+        if (listed.some((record) => record.id === createdBotId)) return listed;
+        return [{ id: createdBotId, unique_name: uniqueName }, ...listed];
+      }
+    : params.service.listBots;
+
+  const plan = await planCliqHandlerProvisioning({
+    account: params.account,
+    publicWebhookUrl: params.publicWebhookUrl,
+    includeWelcome: params.includeWelcome,
+    reader: {
+      listBots,
+      readHandlerScript: params.service.readHandlerScript,
+    },
+  });
+  if (params.dryRun) return { plan, createdBot };
+
+  const apply = await applyCliqHandlerProvisioning({
+    plan,
+    account: params.account,
+    publicWebhookUrl: params.publicWebhookUrl,
+    confirmed: params.confirmed,
+    writer: {
+      createHandler: params.service.createHandler,
+      updateHandler: params.service.updateHandler,
+      readHandlerScript: params.service.readHandlerScript,
+    },
+  });
+  return { plan, apply, createdBot };
+}

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -28,6 +28,7 @@ import {
 import { resolveCliqSecretString } from "./secret-resolve.js";
 import { resolveCliqDirectoryAllowlist } from "./setup-directory.js";
 import { runCliqSetupOnboarding } from "./setup-onboarding.js";
+import { runCliqSetupProvisioning } from "./setup-provisioning-flow.js";
 import { describeCliqInboundVerification } from "./inbound-verification.js";
 
 const CHANNEL = "cliq" as const;
@@ -632,6 +633,31 @@ const cliqFinalize: NonNullable<ChannelSetupWizard["finalize"]> = async ({
   next = applyCliqInboundVerification(next, readiness);
 
   next = await promptCliqWelcomeOptIn(prompter, next);
+
+  // Issue #94: inspect the Zoho-held bot/handlers and offer idempotent
+  // provisioning. The dry-run is read-only and always runs first; any
+  // mutation (including repairing a handler whose URL matches but whose
+  // secret does not) needs its own explicit confirmation. Without a public
+  // webhook URL there is no target to provision, and a failure here must
+  // never abort a setup whose credentials are already written.
+  if (publicUrl && isCliqChannelConfigured(next)) {
+    try {
+      await runCliqSetupProvisioning({
+        cfg: next,
+        publicWebhookUrl: publicUrl,
+        prompter,
+        accountId: DEFAULT_ACCOUNT_ID,
+        includeWelcome:
+          (readCliqSection(next).welcome as { enabled?: unknown } | undefined)?.enabled === true,
+      });
+    } catch {
+      await noteSafely(
+        prompter,
+        "Bot and handler provisioning could not be inspected; no Zoho-held handler was changed.",
+        "Zoho Cliq bot/handler provisioning",
+      );
+    }
+  }
 
   await runCliqSetupOnboarding({
     cfg: next,


### PR DESCRIPTION
## Summary
- add a read-only provisioning planner plus a confirmation-gated apply step for Message/Mention/Welcome handlers
- implement the minimal-create-then-`PATCH` fallback for Zoho's generic `operation_failed` create, kept observable in the report
- treat `execution_handler_update_failed` as a script-validity fault rather than a retryable error
- treat "bot exists, handlers exist, URL matches, secret does NOT" as a first-class conflict, never "already configured"
- reuse the shared unique-name → internal `b-…` resolver from #149 instead of a second lookup path

## Safety
- planning never mutates; applying requires an explicit confirmation defaulting to no
- unreadable handlers, hand-written scripts, and a Zoho-derived unique-name mismatch block instead of being overwritten
- every write is read back before it is reported as successful
- handler bodies, secrets, and OAuth material never reach plans, notes, or reports (fingerprints only)

## Verification
- `npx tsc --noEmit`
- `npm test` (86 files, 1877 tests)
- `npm run build`
- `npm run smoke:gateway`

Live acceptance against a real organization remains a human step, tracked in ROADMAP.

Closes #94
