### PR TITLE
ci(deps): add conservative Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    assignees:
+      - martinalbrecht-berlin
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      development-tooling:
+        dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - openclaw
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 3
+    assignees:
+      - martinalbrecht-berlin
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,19 @@ When reporting, please include:
 - a description of the issue and its impact;
 - reproduction steps or a proof of concept, if available.
 
+## Dependency security updates
+
+The repository maintainers review Dependabot alerts and pull requests for npm
+and GitHub Actions updates. Dependabot never auto-merges changes: every update
+must pass typecheck, tests, build, gateway smoke, and the supported OpenClaw
+compatibility matrix before a maintainer merges it.
+
+The pinned `openclaw` development dependency is intentionally excluded from
+grouped updates because it is coupled to `.github/openclaw-compat.json` and
+requires an explicit compatibility review. Breaking dependency updates should
+use a dedicated pull request that explains the migration and audit impact; do
+not apply `npm audit fix --force` blindly.
+
 ## Scope
 
 This plugin handles Zoho Cliq bot credentials (OAuth client secret, refresh


### PR DESCRIPTION
## Summary
- add weekly Dependabot updates for npm and GitHub Actions
- group patch/minor development-tool updates while keeping OpenClaw explicit
- document maintainer review, no-automerge, and breaking-update policy

## Verification
- validates against the Dependabot 2.0 SchemaStore schema
- `npm audit` (0 vulnerabilities)
- `npx tsc --noEmit`
- `npm test` (1,967 tests)
- `npm run build`
- `npm run smoke:gateway`

Closes #157