### PR TITLE
docs(readme): recommend combined OAuth scope profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ publish workflow extracts the matching section as the release notes (see
 
 ### Changed
 
+- **New installations are now directed to the combined 14-scope OAuth profile first (issue #192).** README §3b recommends one initial consent covering runtime messaging plus bot/handler inspection and provisioning. The 11-scope runtime-only profile remains available as an explicitly minimal alternative, with a warning that Zoho does not add scopes retroactively: expanding it later requires re-consent and a regenerated refresh token.
+
 - **Breaking: OpenClaw `2026.8.1-beta.3` is now the minimum supported runtime (issue #189).** Older OpenClaw versions are no longer supported or tested. The plugin API range, minimum gateway version, peer dependency, compatibility matrix, and current installation guidance now require Beta 3 or later; the build metadata and development dependency remain pinned to exactly `2026.8.1-beta.3`.
 
 - **Block streaming is now the default (issue #181).** An unset

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ The plugin uses **two** OAuth grant types, because the **`client_credentials`** 
 
 #### 3b. Consent the scopes
 
-When registering / re-consenting the self-client, request **all eleven** scopes so both the `client_credentials` (DM) and refresh-token (channel/edit/delete/card/media/typing) paths work:
+> **Consent once with everything you might need.** Zoho **scopes are not added retroactively** to an existing consent. If you start with the runtime-only string and later want bot inspection or handler provisioning from `openclaw setup`, you must re-consent the Self Client with the larger scope string and regenerate the refresh token — a second Generate Code round trip with a fresh 10-minute code. Pasting the combined profile below on the first attempt avoids that entirely; consenting a scope you never use costs nothing at runtime.
+
+For a new installation, paste the **combined profile** from [Capability profiles](#capability-profiles) into the Self Client's Generate Code scope field. The individual scopes and what each one unlocks are listed here; both the `client_credentials` (DM) and refresh-token (channel/edit/delete/card/media/typing) paths need to be covered:
 
 Each scope's grant is shown in parentheses — *client_credentials* is fetched automatically; *refresh token* requires the one-time [§3c](#3c-obtain-the-user-context-refresh-token-required-for-channel-posts--edits) token.
 
@@ -195,9 +197,23 @@ The plugin defines two **capability profiles** — each a named set of OAuth sco
 with a specific grant type. The capability matrix in `src/capabilities.ts` is the
 single source of truth; `openclaw doctor` validates capabilities at setup time.
 
-**Runtime profile** — scopes required for normal DM/channel messaging and optional
-features. Copy this comma-separated string into the Zoho API Console's Generate Code
-scope field:
+**Combined profile (recommended)** — runtime + setup in a single consent (14
+scopes). This is the string to use for a new installation: one paste, one code
+exchange, and both normal messaging and bot/handler provisioning from
+`openclaw setup` work without a second consent. Copy it into the Zoho API
+Console's Generate Code scope field:
+
+```
+ZohoCliq.Webhooks.CREATE,ZohoCliq.Channels.UPDATE,ZohoCliq.Messages.UPDATE,ZohoCliq.messageactions.CREATE,ZohoCliq.Attachments.READ,ZohoCliq.Messages.READ,ZohoCliq.Messages.DELETE,ZohoCliq.Channels.CREATE,ZohoCliq.Users.READ,ZohoCliq.Channels.READ,ZohoCliq.Chats.UPDATE,ZohoCliq.Bots.READ,ZohoCliq.Bots.CREATE,ZohoCliq.Bots.UPDATE
+```
+
+The two tables below break that string into its runtime and setup halves.
+
+**Runtime-only profile (minimal alternative)** — the 11 scopes required for
+normal DM/channel messaging and optional messaging features, with no bot
+inspection or provisioning. Use this only if you are certain you will never
+provision bots or handlers from `openclaw setup`; adding those scopes later
+means re-consenting and regenerating the refresh token:
 
 ```
 ZohoCliq.Webhooks.CREATE,ZohoCliq.Channels.UPDATE,ZohoCliq.Messages.UPDATE,ZohoCliq.messageactions.CREATE,ZohoCliq.Attachments.READ,ZohoCliq.Messages.READ,ZohoCliq.Messages.DELETE,ZohoCliq.Channels.CREATE,ZohoCliq.Users.READ,ZohoCliq.Channels.READ,ZohoCliq.Chats.UPDATE
@@ -244,12 +260,6 @@ ZohoCliq.Bots.READ,ZohoCliq.Bots.CREATE,ZohoCliq.Bots.UPDATE
 The bot/handler endpoint, method, and body details verified live — including the
 internal `b-...` bot ID requirement — are recorded in the
 [verified provisioning API contract](https://github.com/sprintberlin/openclaw-cliq/blob/main/docs/setup/provisioning-api-contract.md).
-
-**Combined profile** — runtime + setup in a single consent:
-
-```
-ZohoCliq.Webhooks.CREATE,ZohoCliq.Channels.UPDATE,ZohoCliq.Messages.UPDATE,ZohoCliq.messageactions.CREATE,ZohoCliq.Attachments.READ,ZohoCliq.Messages.READ,ZohoCliq.Messages.DELETE,ZohoCliq.Channels.CREATE,ZohoCliq.Users.READ,ZohoCliq.Channels.READ,ZohoCliq.Chats.UPDATE,ZohoCliq.Bots.READ,ZohoCliq.Bots.CREATE,ZohoCliq.Bots.UPDATE
-```
 
 #### 3c. Obtain the user-context refresh token (required for channel posts + edits)
 
@@ -308,7 +318,7 @@ exchange for a permanent **refresh token**.
 **Step 1 — generate the code (valid 10 minutes):**
 
 1. In the **[Zoho API Console](https://api-console.zoho.com)** ([your data center](#data-centers)) → your **Self Client** → tab **Generate Code**.
-2. **Scope** (the Self Client field is comma-separated, no spaces):
+2. **Scope:** paste the **combined 14-scope profile** below (comma-separated, no spaces). Zoho scopes are not added retroactively: choosing the runtime-only alternative now and adding setup/provisioning later requires a new consent and a regenerated refresh token.
    ```
    ZohoCliq.Webhooks.CREATE,ZohoCliq.Channels.UPDATE,ZohoCliq.Messages.UPDATE,ZohoCliq.messageactions.CREATE,ZohoCliq.Attachments.READ,ZohoCliq.Messages.READ,ZohoCliq.Messages.DELETE,ZohoCliq.Channels.CREATE,ZohoCliq.Users.READ,ZohoCliq.Channels.READ,ZohoCliq.Chats.UPDATE,ZohoCliq.Bots.READ,ZohoCliq.Bots.CREATE,ZohoCliq.Bots.UPDATE
    ```

--- a/src/scope-docs.test.ts
+++ b/src/scope-docs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { FULL_SCOPE_STRING, RUNTIME_SCOPE_STRING } from "./capabilities.js";
+
+const ROOT = join(new URL(".", import.meta.url).pathname, "..");
+const readme = readFileSync(join(ROOT, "README.md"), "utf8");
+
+describe("README scope guidance (issue #192)", () => {
+  it("publishes both canonical scope strings verbatim", () => {
+    expect(readme).toContain(FULL_SCOPE_STRING);
+    expect(readme).toContain(RUNTIME_SCOPE_STRING);
+  });
+
+  it("recommends the combined profile before the runtime-only alternative", () => {
+    const combinedHeading = readme.indexOf("**Combined profile (recommended)**");
+    const runtimeHeading = readme.indexOf("**Runtime-only profile (minimal alternative)**");
+    expect(combinedHeading).toBeGreaterThan(-1);
+    expect(runtimeHeading).toBeGreaterThan(-1);
+    expect(combinedHeading).toBeLessThan(runtimeHeading);
+  });
+
+  it("presents the combined string before the runtime-only string", () => {
+    expect(readme.indexOf(FULL_SCOPE_STRING)).toBeLessThan(
+      readme.indexOf(`\n${RUNTIME_SCOPE_STRING}\n`),
+    );
+  });
+
+  it("warns that Zoho consent is not extended retroactively", () => {
+    expect(readme).toMatch(/scopes are not added retroactively/i);
+    expect(readme).toMatch(/re-consent[\s\S]{0,400}regenerate the refresh token/i);
+  });
+});


### PR DESCRIPTION
## Summary

- recommend the combined 14-scope profile first for new installations
- keep the 11-scope runtime-only profile as an explicitly minimal alternative
- warn at §3b and Generate Code that Zoho does not add scopes retroactively
- lock the profile order and canonical strings with a README regression test

Closes #192

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (config or behavior)
- [x] Docs / tooling / CI only

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm test` passes (92 files / 2075 tests)
- [x] `npm run build` succeeds
- [x] `npm run check:sdk-compat` passes (36/36)
- [x] PR title follows Conventional Commits
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Updated README
- [x] No secrets in the diff, tests, or fixtures

## Notes for reviewers

The runtime-only scope string remains documented verbatim. The combined canonical string is now the first scope block in the profile section and the one copied into §3c Generate Code.