### PR TITLE
fix(doctor): separate unprovisioned handlers from missing consent (#249) + docs (#243 #245 #250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ publish workflow extracts the matching section as the release notes (see
 
 ## [Unreleased]
 
+### Fixed
+
+- Doctor distinguishes an unprovisioned Message/Mention handler (`400 execution_handler_not_found`) from missing `ZohoCliq.Bots.READ` consent, points new bots to handler provisioning, and leaves unrelated failures as unreadable state (#249).
+
+### Documentation
+
+- Bot-creation instructions now match the Zoho API/MCP schema: Cliq assigns `unique_name`; API callers provide `name`, required `scope`, `execution_type`, and `channel_participation` (#243).
+- Public-webhook setup documents the domain-free sslip.io/nip.io + Caddy path and its security/availability caveats (#245).
+- Handler provisioning warns that Zoho MCP handler sub-resource tools return `400 request_url_invalid`; use direct REST or `openclaw setup` (#250).
+
 ## [0.3.0] - 2026-09-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ Open the bot builder: click your **profile picture** (top-right in Zoho Cliq) �
 1. In **Bots & Tools**, open the **Bots** section.
 2. Click **Create Bot**.
 3. Fill in:
-   - **Bot Name** (display name, e.g. `OpenClaw Agent`) — this is what users see.
-   - **Bot Unique Name** (e.g. `openclaw_agent`) — this is the `botId` you will put in the plugin config. Lowercase, underscores, no spaces.
+   - **Bot Name** (display name, e.g. `OpenClaw Agent`, max 20 characters) — this is what users see.
    - **Bot Type**: choose **Custom Bot** (a Deluge-backed bot whose handlers forward to the webhook). A pure "Webhook Bot" is not required — we use a Custom Bot with a Deluge handler that `invokeUrl`s our endpoint.
+
+   Cliq assigns the **unique name** itself from the display name; it is not a field you fill in. Read it back from the created bot — that assigned value is the `botId` you put in the plugin config.
+
+   Creating the same bot over the API (or the Zoho MCP server's `ZohoCliq_create_bot`) uses different field names than this form: `name`, `description`, `scope` (`organization` | `team` | `personal`, required), `execution_type` (`deluge` | `webhook`), and `channel_participation`. There is no `bot_unique_name` or `bot_type` field — both are rejected as `extra_key_found`, and `unique_name` comes back in the response.
 4. Set the bot's **Functional Handlers**:
    - **Mention Handler** — fired when the bot is @mentioned in a channel.
    - **Message Handler** — fired when a user DMs the bot directly.
@@ -111,7 +114,7 @@ The plugin registers a single HTTP route at **`POST /cliq/webhook`** on your Ope
 
    The route is registered with `auth: "plugin"`, so no additional gateway-level bearer token is required; the `webhookSecret` is verified by the plugin itself via the `x-cliq-webhook-secret` header.
 
-3. Make sure the gateway host is reachable from the public internet (Zoho's servers POST to it). See **[Expose the webhook publicly](https://github.com/sprintberlin/openclaw-cliq/blob/main/docs/setup/public-webhook.md)** for deployment options (VPS + reverse proxy, Cloudflare Tunnel, existing proxy, dev tunnels, self-hosted tunnel) with secure Caddy and nginx examples.
+3. Make sure the gateway host is reachable from the public internet (Zoho's servers POST to it). See **[Expose the webhook publicly](https://github.com/sprintberlin/openclaw-cliq/blob/main/docs/setup/public-webhook.md)** for deployment options (VPS + reverse proxy, domain-free sslip.io/nip.io + Caddy, Cloudflare Tunnel, existing proxy, dev tunnels, self-hosted tunnel) with secure Caddy and nginx examples.
 
    Verify the public path before wiring up Zoho — this checks DNS, TLS, the reverse proxy, the route, and the shared secret, and finishes with a probe that reaches the plugin without dispatching an agent turn:
 
@@ -631,6 +634,8 @@ Every field except the required ones has a sensible default; `groups` / `thinkin
 The Cliq bot must forward every mention / message event to the OpenClaw webhook. The two handlers use **almost** the same script, but they are **not** interchangeable — see the note after the script.
 
 > **`openclaw setup` can do this for you.** When `publicWebhookUrl` is configured and the OAuth client carries the provisioning scopes from [§3b](#3b-oauth-scopes), setup shows a **read-only dry-run** of the Zoho-held handlers and then offers to create or repair them; a newly created bot includes Zoho's required non-empty description, and the Welcome handler is included only when the greeting is opted in. Nothing is changed without a separate confirmation that defaults to *no*. A handler whose URL matches but whose **secret differs** is reported as a conflict rather than "already configured" — that state passes the preflight while real inbound traffic fails with `401`. Unreadable and hand-written handlers are never overwritten, and every write is read back before it counts as successful. The steps below remain the manual path, and are still the correct route when you prefer not to grant `ZohoCliq.Bots.CREATE` / `ZohoCliq.Bots.UPDATE`.
+
+> **Do not provision handlers through the Zoho MCP server.** Its `ZohoCliq_create_bot_handler` / `ZohoCliq_get_bot_handler` / `ZohoCliq_update_bot_handler` tools fail with `400 request_url_invalid` regardless of bot-id format, while bot-level tools on the same server work. Use `openclaw setup`, the manual paste below, or the direct REST endpoints in [the provisioning API contract](https://github.com/sprintberlin/openclaw-cliq/blob/main/docs/setup/provisioning-api-contract.md).
 
 > **Where to find them:** in the Cliq Bot editor open **Edit Handlers**, then click *Edit Code* on **Message Handler** (DMs) and **Mention Handler** (channel @mentions) — the two arrowed below.
 

--- a/docs/setup/provisioning-api-contract.md
+++ b/docs/setup/provisioning-api-contract.md
@@ -2,6 +2,8 @@
 
 This document records the Zoho Cliq REST API behavior verified live against the EU data center. Bot create currently requires a non-empty `description` in addition to `name` and `scope: "organization"` (EU, 2026-08-29). It is the contract for bot and handler provisioning work; it is not a substitute for the normal manual setup instructions in the [README](../../README.md).
 
+> **This contract applies to the direct REST API only.** The Zoho MCP server's handler sub-resource tools (`ZohoCliq_create_bot_handler`, `ZohoCliq_get_bot_handler`, `ZohoCliq_update_bot_handler`) route incorrectly and answer `400 request_url_invalid` for every bot-id format — internal `b-…`, bare numeric, and unique name alike. Bot-level tools on the same server work, which makes the handler failure look like an API defect rather than a routing one. Use the endpoints below or `openclaw setup`.
+
 ## Bot endpoints
 
 ### Create a bot

--- a/docs/setup/public-webhook.md
+++ b/docs/setup/public-webhook.md
@@ -278,6 +278,47 @@ constant-time secret check and expects the request to arrive unmodified.
 
 ---
 
+## Option 1a — No domain: sslip.io / nip.io + Caddy
+
+A public VPS needs HTTPS but not necessarily a domain you own. IP-encoding
+wildcard DNS services resolve a hostname directly to the IP written into it:
+
+```text
+83-141-21-119.sslip.io  →  83.141.21.119
+```
+
+Use that hostname as the Caddy site address; no DNS account or zone setup is
+required:
+
+```caddyfile
+83-141-21-119.sslip.io {
+	handle /cliq/webhook {
+		reverse_proxy 127.0.0.1:18789
+	}
+
+	handle {
+		respond 404
+	}
+}
+```
+
+Open TCP 80 for the ACME HTTP-01 challenge and redirect, and TCP 443 for the
+webhook. Keep port 18789 private. Caddy obtains and renews a normal Let's
+Encrypt certificate automatically. Verify the result before provisioning:
+
+```bash
+openclaw cliq webhook-preflight https://83-141-21-119.sslip.io/cliq/webhook
+```
+
+Caveats:
+
+- sslip.io and nip.io are free third-party DNS services; prefer a domain you
+  control for long-lived production deployments.
+- The hostname exposes the VPS IP.
+- Let's Encrypt rate limits still apply.
+- To migrate later, change the Caddy site address, rerun `webhook-preflight`,
+  and update both Zoho handler URLs (`openclaw setup` can repair them).
+
 ## Option 2 — Cloudflare Tunnel
 
 The right choice for a machine **behind NAT** — a desktop agent, a home

--- a/src/bot-inspect.test.ts
+++ b/src/bot-inspect.test.ts
@@ -295,3 +295,43 @@ describe("inspectCliqBot — disclosure", () => {
     expect(serialized).not.toContain(WEBHOOK_SECRET);
   });
 });
+
+describe("toCliqDoctorBotInspection — handler remediation (issue #249)", () => {
+  const notProvisioned = {
+    error: "Zoho answered HTTP 400",
+    errorCode: "execution_handler_not_found",
+    errorStatus: 400,
+  };
+
+  it("sends an unprovisioned bot to provisioning, never to re-consenting Bots.READ", async () => {
+    const result = await inspectCliqBot({
+      account: account(),
+      publicWebhookUrl: "https://cliq.example.com/cliq/webhook",
+      reader: reader({
+        getBot: vi.fn(async () => botRecord({ handlers: [] })),
+        readHandlerScript: vi.fn(async () => notProvisioned),
+      }),
+    });
+    const doctor = toCliqDoctorBotInspection(result);
+    expect(doctor.status).toBe("warn");
+    const remediation = doctor.remediation?.join(" ") ?? "";
+    expect(remediation).toMatch(/provision/i);
+    expect(remediation).not.toMatch(/Grant and re-consent ZohoCliq\.Bots\.READ/);
+  });
+
+  it("keeps the re-consent remediation when the read is genuinely unauthorized", async () => {
+    const result = await inspectCliqBot({
+      account: account(),
+      publicWebhookUrl: "https://cliq.example.com/cliq/webhook",
+      reader: reader({
+        readHandlerScript: vi.fn(async () => ({
+          error: "Zoho refused the read with HTTP 401",
+          errorStatus: 401,
+        })),
+      }),
+    });
+    const doctor = toCliqDoctorBotInspection(result);
+    const remediation = doctor.remediation?.join(" ") ?? "";
+    expect(remediation).toMatch(/Grant and re-consent ZohoCliq\.Bots\.READ/);
+  });
+});

--- a/src/bot-inspect.ts
+++ b/src/bot-inspect.ts
@@ -54,7 +54,12 @@ export interface CliqBotReader {
   listBots(maxItems?: number): Promise<CliqBotRecord[] | CliqBotReadFailure>;
   getBot(botId: string): Promise<CliqBotRecord | CliqBotReadFailure>;
   listSubscribers(botIdOrUniqueName: string, maxItems?: number): Promise<CliqBotSubscriberPage | CliqBotReadFailure>;
-  readHandlerScript(handlerType: string, botId?: string): Promise<{ script?: string; error?: string }>;
+  readHandlerScript(handlerType: string, botId?: string): Promise<{
+    script?: string;
+    error?: string;
+    errorCode?: string;
+    errorStatus?: number;
+  }>;
 }
 
 export interface CliqDoctorBotInspectionView {
@@ -134,7 +139,13 @@ async function readHandlers(
   for (const type of CLIQ_INBOUND_HANDLER_TYPES) {
     try {
       const result = await reader.readHandlerScript(type, botId);
-      handlers.push({ type, script: result.script, error: result.error });
+      handlers.push({
+        type,
+        script: result.script,
+        error: result.error,
+        errorCode: result.errorCode,
+        errorStatus: result.errorStatus,
+      });
     } catch {
       handlers.push({ type, error: "the handler read threw an unexpected error" });
     }
@@ -293,12 +304,17 @@ export function toCliqDoctorBotInspection(
     inspection.handlerContentShapes.status === "uncovered" ||
     inspection.handlerContentShapes.status === "declared_unexercised"
   ) {
+    const handlerRemediation = inspection.handlerConsistency.readProblem === "handler_not_provisioned"
+      ? [
+          "Provision the Message and Mention handlers with the provisioning stage in `openclaw setup`, or paste the manual §5 Deluge handlers / use the direct REST contract in docs/setup/provisioning-api-contract.md. This new-bot state is not a ZohoCliq.Bots.READ consent failure.",
+        ]
+      : [
+          "Grant and re-consent ZohoCliq.Bots.READ; subscriber details additionally require the bot creator or an organization administrator. Use a real Cliq client to send one native reply/quote and one forwarded message: the bot send API cannot synthesize either relationship, and static field declarations are not live delivery proof.",
+        ];
     return {
       status: "warn",
       evidence,
-      remediation: [
-        "Grant and re-consent ZohoCliq.Bots.READ; subscriber details additionally require the bot creator or an organization administrator. Use a real Cliq client to send one native reply/quote and one forwarded message: the bot send API cannot synthesize either relationship, and static field declarations are not live delivery proof.",
-      ],
+      remediation: handlerRemediation,
     };
   }
   return { status: "pass", evidence };

--- a/src/client.ts
+++ b/src/client.ts
@@ -2956,18 +2956,25 @@ export class CliqClient {
    * fingerprint comparison and is never logged, never embedded in an error
    * message, and never surfaced in a diagnostic report. A failure is reduced
    * to its HTTP status so an error body (which can echo request content)
-   * cannot leak either.
+   * cannot leak either. The stable error code is preserved separately so
+   * diagnostics can distinguish an unprovisioned handler from a missing
+   * `Bots.READ` consent without surfacing the raw response.
    */
   async readBotHandlerScript(
     handlerType: string,
     internalBotId = this.botId,
-  ): Promise<{ script?: string; error?: string }> {
+  ): Promise<{
+    script?: string;
+    error?: string;
+    errorCode?: string;
+    errorStatus?: number;
+  }> {
     const path = `/api/v3/bots/${encodeURIComponent(internalBotId)}/handlers/${encodeURIComponent(handlerType)}`;
     let token: string;
     try {
       token = await this.getAccessToken("ZohoCliq.Bots.READ");
     } catch {
-      return { error: "could not mint a ZohoCliq.Bots.READ access token" };
+      return { error: "could not mint a ZohoCliq.Bots.READ access token", errorCode: "missing_scope" };
     }
     let res: { ok: boolean; status: number; json: () => Promise<unknown> };
     try {
@@ -2979,11 +2986,23 @@ export class CliqClient {
       return { error: `the request to read the ${handlerType} failed at the transport layer` };
     }
     if (!res.ok) {
+      let code: string | undefined;
+      try {
+        const data = await res.json();
+        const value = data && typeof data === "object" && typeof (data as { code?: unknown }).code === "string"
+          ? (data as { code: string }).code
+          : undefined;
+        code = value?.toLowerCase();
+      } catch {
+        // The reduced error below deliberately omits any response body.
+      }
       return {
         error:
           res.status === 401 || res.status === 403
             ? `Zoho refused the read with HTTP ${res.status} — the token is probably missing the ZohoCliq.Bots.READ scope`
             : `Zoho answered HTTP ${res.status}`,
+        errorCode: code,
+        errorStatus: res.status,
       };
     }
     let data: unknown;

--- a/src/doctor-runner.ts
+++ b/src/doctor-runner.ts
@@ -115,7 +115,12 @@ export interface CliqDoctorClient {
   getApiBase(): string;
   listUsers(maxItems?: number): Promise<CliqDirectoryEntry[]>;
   listChannels(maxItems?: number): Promise<CliqDirectoryEntry[]>;
-  readBotHandlerScript?(handlerType: string, botId?: string): Promise<{ script?: string; error?: string }>;
+  readBotHandlerScript?(handlerType: string, botId?: string): Promise<{
+    script?: string;
+    error?: string;
+    errorCode?: string;
+    errorStatus?: number;
+  }>;
   listBots?(maxItems?: number): ReturnType<CliqBotReader["listBots"]>;
   getBot?(botId: string): ReturnType<CliqBotReader["getBot"]>;
   listBotSubscribers?(botIdOrUniqueName: string, maxItems?: number): ReturnType<CliqBotReader["listSubscribers"]>;

--- a/src/handler-consistency.test.ts
+++ b/src/handler-consistency.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   checkCliqHandlerConsistency,
+  classifyCliqHandlerReadProblem,
   createCliqHandlerScriptReader,
   extractDelugeStringAssignment,
   fingerprintCliqSecret,
@@ -480,5 +481,94 @@ describe("proposeCliqHandlerUrlAdoption (issue #172)", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toMatch(/mention/i);
+  });
+});
+
+describe("handler-read classification (issue #249)", () => {
+  const notProvisioned = {
+    error: "Zoho answered HTTP 400",
+    errorCode: "execution_handler_not_found",
+    errorStatus: 400,
+  };
+
+  it("classifies execution_handler_not_found as an unprovisioned handler, not a scope failure", () => {
+    expect(classifyCliqHandlerReadProblem(notProvisioned)).toBe("handler_not_provisioned");
+  });
+
+  it("classifies a 401 and an explicit scope code as a consent failure", () => {
+    expect(
+      classifyCliqHandlerReadProblem({ error: "Zoho refused the read with HTTP 401", errorStatus: 401 }),
+    ).toBe("missing_scope");
+    expect(
+      classifyCliqHandlerReadProblem({
+        error: "could not mint a ZohoCliq.Bots.READ access token",
+        errorCode: "missing_scope",
+      }),
+    ).toBe("missing_scope");
+  });
+
+  it("leaves any other failure unreadable rather than guessing a cause", () => {
+    expect(classifyCliqHandlerReadProblem({ error: "Zoho answered HTTP 500", errorStatus: 500 })).toBe(
+      "unreadable",
+    );
+  });
+
+  it("reports an unprovisioned handler as such and never as a missing script body", () => {
+    const result = checkCliqHandlerConsistency({
+      handlers: [
+        { type: "message_handler", ...notProvisioned },
+        { type: "mention_handler", ...notProvisioned },
+      ],
+      configSecret: SECRET,
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.readProblem).toBe("handler_not_provisioned");
+    expect(result.detail).toMatch(/not provisioned yet/i);
+    expect(result.detail).toMatch(/execution_handler_not_found/);
+  });
+
+  it("keeps the scope diagnosis when the read is genuinely unauthorized", () => {
+    const result = checkCliqHandlerConsistency({
+      handlers: [
+        { type: "message_handler", error: "Zoho refused the read with HTTP 401", errorStatus: 401 },
+        { type: "mention_handler", error: "Zoho refused the read with HTTP 401", errorStatus: 401 },
+      ],
+      configSecret: SECRET,
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.readProblem).toBe("missing_scope");
+    expect(result.detail).not.toMatch(/not provisioned yet/i);
+  });
+
+  it("prefers the unprovisioned diagnosis when one handler exists and the other does not", () => {
+    const result = checkCliqHandlerConsistency({
+      handlers: [
+        { type: "message_handler", script: script() },
+        { type: "mention_handler", ...notProvisioned },
+      ],
+      configSecret: SECRET,
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.readProblem).toBe("handler_not_provisioned");
+  });
+
+  it("points the preflight note at provisioning instead of re-consent", () => {
+    const lines = formatCliqPreflightReport({
+      ok: true,
+      url: HOOK_URL,
+      nonce: "nonce-value",
+      dispatched: false,
+      stages: [
+        {
+          id: "handler_secret",
+          status: "skipped",
+          label: "Handler secret",
+          detail:
+            "the Zoho-held webhook secret could not be completely compared: message handler is not provisioned yet (Zoho returned execution_handler_not_found).",
+        },
+      ],
+    }).join(" ");
+    expect(lines).toMatch(/not provisioned/i);
+    expect(lines).not.toMatch(/Grant ZohoCliq\.Bots\.READ and rerun/);
   });
 });

--- a/src/handler-consistency.ts
+++ b/src/handler-consistency.ts
@@ -51,12 +51,72 @@ export interface CliqHandlerScriptRecord {
   type: string;
   script?: string | null;
   error?: string;
+  /**
+   * Stable error code from Zoho's handler-read response, when available.
+   * Keep this separate from `error`: the latter is deliberately redacted,
+   * human-readable diagnostic text and must never contain the response body.
+   */
+  errorCode?: string;
+  /** HTTP status from the handler-read response, when available. */
+  errorStatus?: number;
 }
 
 export interface CliqHandlerConsistencyResult {
   status: CliqHandlerConsistencyStatus;
   /** Human-readable, fingerprint-only summary. Never contains a secret. */
   detail: string;
+  /**
+   * Why a handler could not be read, when that is the limiting evidence.
+   * This lets doctor offer a targeted repair instead of treating every 4xx as
+   * a missing OAuth consent.
+   */
+  readProblem?: CliqHandlerReadProblem;
+}
+
+export type CliqHandlerReadProblem =
+  | "handler_not_provisioned"
+  | "missing_scope"
+  | "unreadable";
+
+/**
+ * Classify a reduced, non-secret handler-read failure.
+ *
+ * `execution_handler_not_found` is a normal new-bot state: Cliq has no
+ * stored handler to read yet. It must not be diagnosed as a `Bots.READ`
+ * consent problem merely because the endpoint uses an HTTP 400 response.
+ */
+export function classifyCliqHandlerReadProblem(
+  handler: Pick<CliqHandlerScriptRecord, "error" | "errorCode" | "errorStatus">,
+): CliqHandlerReadProblem {
+  const code = handler.errorCode?.trim().toLowerCase();
+  if (code === "execution_handler_not_found") return "handler_not_provisioned";
+  if (handler.errorStatus === 401 || code === "oauthtoken_scope_invalid" || code?.includes("scope")) {
+    return "missing_scope";
+  }
+  return "unreadable";
+}
+
+function describeHandlerReadFailure(handler: CliqHandlerScriptRecord): string {
+  const label = describeHandler(handler.type);
+  switch (classifyCliqHandlerReadProblem(handler)) {
+    case "handler_not_provisioned":
+      return `${label} is not provisioned yet (Zoho returned execution_handler_not_found)`;
+    case "missing_scope":
+      return `${label} could not be read (${handler.error ?? "Zoho rejected the handler read as unauthorized"})`;
+    case "unreadable":
+      return `${label} could not be read (${handler.error ?? "no script body was returned"})`;
+  }
+}
+
+function mostSpecificHandlerReadProblem(
+  handlers: readonly CliqHandlerScriptRecord[],
+): CliqHandlerReadProblem | undefined {
+  const problems = handlers
+    .filter((handler) => handler.error || typeof handler.script !== "string" || handler.script.length === 0)
+    .map(classifyCliqHandlerReadProblem);
+  if (problems.includes("handler_not_provisioned")) return "handler_not_provisioned";
+  if (problems.includes("missing_scope")) return "missing_scope";
+  return problems.includes("unreadable") ? "unreadable" : undefined;
 }
 
 /**
@@ -291,9 +351,7 @@ export function checkCliqHandlerConsistency(
   for (const handler of options.handlers) {
     const label = describeHandler(handler.type);
     if (handler.error || typeof handler.script !== "string" || handler.script.length === 0) {
-      skips.push(
-        `${label} could not be read (${handler.error ?? "no script body was returned"})`,
-      );
+      skips.push(describeHandlerReadFailure(handler));
       continue;
     }
     const handlerSecret = extractDelugeStringAssignment(handler.script, "webhookSecret");
@@ -393,12 +451,14 @@ export function checkCliqHandlerConsistency(
     return { status: "fail", detail: `${failures.join("; ")}.${trailer}` };
   }
   if (skips.length > 0) {
+    const readProblem = mostSpecificHandlerReadProblem(options.handlers);
     const compared = matched.length > 0
       ? ` ${matched.join(" and ")} matched, but equality cannot be claimed for every inbound path.`
       : "";
     return {
       status: "skipped",
       detail: `the Zoho-held webhook secret could not be completely compared: ${skips.join("; ")}.${compared}`,
+      readProblem,
     };
   }
   return {
@@ -526,7 +586,12 @@ export function createCliqHandlerScriptReader(params: {
   readHandlerScript: (
     handlerType: string,
     botId?: string,
-  ) => Promise<{ script?: string; error?: string }>;
+  ) => Promise<{
+    script?: string;
+    error?: string;
+    errorCode?: string;
+    errorStatus?: number;
+  }>;
   listBots: CliqBotIdLister;
 }): (() => Promise<CliqHandlerScriptRecord[]>) | null {
   if (!params.account.botId) return null;
@@ -543,7 +608,13 @@ export function createCliqHandlerScriptReader(params: {
     for (const type of CLIQ_INBOUND_HANDLER_TYPES) {
       try {
         const result = await params.readHandlerScript(type, resolved.botId);
-        records.push({ type, script: result.script, error: result.error });
+        records.push({
+          type,
+          script: result.script,
+          error: result.error,
+          errorCode: result.errorCode,
+          errorStatus: result.errorStatus,
+        });
       } catch {
         records.push({ type, error: "the handler read threw an unexpected error" });
       }

--- a/src/webhook-preflight.ts
+++ b/src/webhook-preflight.ts
@@ -713,9 +713,10 @@ export function formatCliqPreflightReport(report: CliqPreflightReport): string[]
   // authenticated" be read as "Zoho can deliver" (issue #124).
   const handlerStage = report.stages.find((stage) => stage.id === "handler_secret");
   if (report.ok && handlerStage && handlerStage.status === "skipped") {
-    lines.push(
-      "Note: this does NOT prove Zoho holds the same webhook secret — the checks above used the configured secret against your own endpoint. Grant ZohoCliq.Bots.READ and rerun to compare the bot's handler scripts.",
-    );
+    const handlerNotProvisioned = /execution_handler_not_found|not provisioned yet/i.test(handlerStage.detail);
+    lines.push(handlerNotProvisioned
+      ? "Note: this does NOT prove Zoho can deliver yet — the Message and Mention handlers are not provisioned. Use openclaw setup or the manual §5/direct-REST provisioning path; re-consenting ZohoCliq.Bots.READ will not create handlers."
+      : "Note: this does NOT prove Zoho holds the same webhook secret — the checks above used the configured secret against your own endpoint. Grant ZohoCliq.Bots.READ and rerun to compare the bot's handler scripts.");
   }
   return lines;
 }


### PR DESCRIPTION
## Summary

One behavior fix and three documentation gaps found during the live EU install.

| Commit | Issue | What it changes |
|---|---|---|
| `9503098` | #249 | Doctor no longer reads `400 execution_handler_not_found` as a missing `ZohoCliq.Bots.READ` consent |
| `0ccb663` | #243 | README bot creation matches the Zoho API/MCP schema |
| `8ac17e3` | #245 | Domain-free `sslip.io`/`nip.io` + Caddy webhook path |
| `94a5e6b` | #250 | Warning that MCP handler sub-resource tools route incorrectly |

## #249 in detail

A freshly created bot has no handlers, and reading one answers `400` with
`{"code":"execution_handler_not_found"}`. Every non-2xx handler read was treated
as consent evidence, so the report recommended re-consenting a scope the *same
report* had already shown as `bot_read=pass` — while the real fix, provisioning
the handlers, went unmentioned.

`readBotHandlerScript` now keeps Zoho's stable error code and HTTP status next to
the reduced error text. Classification:

- `execution_handler_not_found` → "not provisioned yet" + provisioning remediation
- `401` / explicit scope codes → existing re-consent remediation
- everything else → unreadable state, no consent hint

The response body is still never surfaced; only the code is retained.

## Verification

- `npm run typecheck` clean
- `npm test` — 102 files, **2357 tests** (9 new)
- `npm run build` + `npm run smoke:gateway` — all 12 stages pass
- **Regression proof:** with the source changes stashed, 8 of the new tests fail; with them applied, all pass.

Live limits: the `400 execution_handler_not_found` shape is reproduced from the
recorded live response, not re-probed against Zoho in this run. The sslip.io
path is documented from the verified install described in #245.