### PR TITLE
fix(inbound): repair Deluge bodies when the generated suffix varies (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ publish workflow extracts the matching section as the release notes (see
 
 ### Fixed
 
+- Deluge-corrupted inbound bodies are now repaired when Zoho varies whitespace or generated-field order after an unescaped multi-line `message` value. Long rejected-body diagnostics preserve a content-masked suffix instead of truncating the structural boundary that explains the failure (#225).
 - Native v3 typing no longer posts to channels/groups by default, because Cliq attributes `/chats/{chatId}/activities` to the human refresh-token owner and exposes no bot sender override. New `heartbeat.typing: "off" | "dm" | "all"` defaults to `"dm"`; ambiguous raw chat IDs fail closed, while `"all"` is an explicit opt-in to the human attribution (#222).
 - Animated thinking placeholders now remain active during otherwise silent tool/reasoning phases even when partial, block, or progress streaming is enabled, then stop and drain any in-flight frame edit before the first real draft update so animation cannot overwrite generated text (#211).
 - Doctor distinguishes an unprovisioned Message/Mention handler (`400 execution_handler_not_found`) from missing `ZohoCliq.Bots.READ` consent, points new bots to handler provisioning, and leaves unrelated failures as unreadable state (#249).

--- a/README.md
+++ b/README.md
@@ -771,7 +771,11 @@ return response;
 > (`handler=mention&message=...`), which is **not** the JSON body this
 > plugin expects — the gateway returns `400 Unexpected token 'h',
 > "handler=me"... is not valid JSON`. Always use `body:` together with
-> the `Content-Type: application/json` header shown above.
+> the `Content-Type: application/json` header shown above. Even on that
+> canonical path, Zoho's `Map.toString()` does not reliably escape quotes or
+> newlines in `message` and may vary whitespace/order in the generated suffix;
+> the webhook repairs recognized generated-handler bodies before parsing.
+> Preserve the generated field names when maintaining handlers manually.
 
 #### 5a. Welcome Handler (optional)
 

--- a/docs/learnings/148-payload-tostring-does-not-escape-repair-at-the-webhook.md
+++ b/docs/learnings/148-payload-tostring-does-not-escape-repair-at-the-webhook.md
@@ -3,18 +3,19 @@ title: Zoho's payload.toString() does not escape string values — repair at the
 category: Zoho Cliq inbound / transport
 files: [src/inbound-deluge-repair.ts, src/inbound.ts, index.ts]
 apis: [payload.toString(), invokeUrl, readJsonBody, JSON.parse]
-issues: [#223, #227, #232]
+issues: [#223, #225, #227, #232]
 ---
 
 Deluge's `Map.toString()` emits JSON-looking text but does not escape string values. A `message` containing a double quote or a line break therefore produces a body that `JSON.parse` rejects even though the payload is structurally complete. Plain messages without quotes/newlines happen to parse — which is why this survived live traffic for months.
 
 Live proof (2026-09-05): a forwarded business instruction arrived as an authenticated 1091-byte POST (the full original text was in the body) and died at `JSON.parse` with `inbound skipped: empty_body`. The earlier theory "forwards carry no readable text" (learning 146) was wrong — the text arrived; the serialization was corrupt.
 
-Durable fix: the webhook repairs the known corruption instead of dropping it. The generated handler's grammar is fixed (`"handler":"…","message":"<free text>","user":…`), so the message value is re-escaped at the last structural `","user":` boundary and re-parsed. Rules that keep this safe:
+Durable fix: the webhook repairs the known corruption instead of dropping it. The generated handler's field vocabulary is fixed, but Deluge may vary insignificant whitespace and map order; the message value is re-escaped at the last parseable separator before a known generated field and the whole object is re-parsed. Rules that keep this safe:
 
 - A body that already parses is never touched (no double-escaping, no hostile re-reading).
 - If the repaired form still fails to parse, fall through to the reject path — never force a value.
 - A text whose corruption happens to parse (it contains a literal `","user":`) defers to the caller's parse; real user text never contains that literal.
-- Unrepairable bodies log a content-free syntax fingerprint (words masked to `x*`, punctuation and marked newlines preserved) so the next unknown corruption shape documents itself without leaking content.
+- A repair is accepted only when the reconstructed object contains the original free text plus object-form `user` and `chat`; separator-like literals or nested keys cannot silently truncate the message.
+- Unrepairable bodies log a bounded content-free syntax fingerprint (words masked to `x*`, punctuation and marked newlines preserved) with both head and structural tail, so the next unknown corruption shape documents itself without leaking content.
 
 Alternative rejected: fixing it in Deluge (e.g. manual escaping loops) would need new handler symbols across every install — the permanent `execution_handler_update_failed` risk — and would not help old handlers already deployed. The gateway-side repair covers all handler generations.

--- a/src/inbound-deluge-repair.test.ts
+++ b/src/inbound-deluge-repair.test.ts
@@ -109,6 +109,15 @@ describe("describeDelugeBodySyntax (issue #227 evidence)", () => {
     const fp = describeDelugeBodySyntax("x".repeat(500));
     expect(fp.length).toBeLessThanOrEqual(96);
   });
+
+  it("keeps the generated suffix visible for a long rejected body", () => {
+    const fp = describeDelugeBodySyntax(
+      `{"handler":"message","message":"${"long text ".repeat(80)}","user":BROKEN_TAIL}`,
+    );
+    expect(fp.length).toBeLessThanOrEqual(96);
+    expect(fp).toContain("…");
+    expect(fp).toMatch(/,"x\*":x\*_x\*}$/);
+  });
 });
 
 describe("repair survives added flat handler fields (#228 regression)", () => {
@@ -129,6 +138,26 @@ describe("repair survives added flat handler fields (#228 regression)", () => {
       '{"handler":"mention","handlerSchema":"v2","locale":"de","message":"sagt "hallo"","user":{"id":"u-2"},"chat":{"id":"c-2"},"eventId":"evt-2"}';
     const repaired = repairDelugeUnescapedMessageBody(raw) as Record<string, unknown>;
     expect(repaired?.message).toBe('sagt "hallo"');
+  });
+
+  it("repairs the live shape when Deluge adds structural whitespace", () => {
+    const raw =
+      '{"handler":"message","handlerSchema":"v2","message":"OPENCLAW_CLIQ_ROUNDTRIP_REQUEST test\nContact email: test@example.invalid\nQuoted text: "doctor-safe"" , "user" : {"id":"u-1","name":"Alice"}, "chat" : {"id":"c-1","type":"single"}, "eventId" : "evt-1"}';
+    const repaired = repairDelugeUnescapedMessageBody(raw) as Record<string, unknown>;
+    expect(repaired).toBeDefined();
+    expect(repaired.message).toBe(
+      'OPENCLAW_CLIQ_ROUNDTRIP_REQUEST test\nContact email: test@example.invalid\nQuoted text: "doctor-safe"',
+    );
+    expect((repaired.user as Record<string, unknown>).id).toBe("u-1");
+    expect((repaired.chat as Record<string, unknown>).id).toBe("c-1");
+  });
+
+  it("finds the generated boundary past a known field name nested in the suffix", () => {
+    const raw =
+      '{"handler":"message","message":"line one\nline "two"","user":{"id":"u-1","profile":{"user":{"id":"nested"}}},"chat":{"id":"c-1"},"eventId":"evt-1"}';
+    const repaired = repairDelugeUnescapedMessageBody(raw) as Record<string, unknown>;
+    expect(repaired.message).toBe('line one\nline "two"');
+    expect((repaired.user as Record<string, unknown>).id).toBe("u-1");
   });
 
   it("does not treat a corrupted marker value as a skippable field", () => {

--- a/src/inbound-deluge-repair.ts
+++ b/src/inbound-deluge-repair.ts
@@ -25,14 +25,13 @@
  * `"handler":"…","message":"` comes free text, and the structural tail
  * (`,"user": … }`) is machine-generated and cannot contain the literal
  * `","user":` inside its own values. The real closing boundary is therefore
- * the **last** occurrence of `","user":` in the body: free text that itself
- * contains that literal sits *before* the real boundary, so `lastIndexOf`
- * finds the real one and the literal stays part of the message text.
- *
- * The message text is re-escaped with `JSON.stringify` and the body is parsed
- * again. Returns `undefined` whenever the body does not match the generated
- * shape or the repaired form still fails to parse — the caller then falls
- * through to the existing reject path with its skip logging (issue #232).
+ * the **last parseable generated-field separator** after the message value.
+ * Deluge may vary insignificant whitespace and Map iteration order, so the
+ * repair tries candidate boundaries before known generated fields from right
+ * to left and accepts only one whose reconstructed suffix parses as the full
+ * generated object. Free text that itself contains a separator-like literal
+ * remains part of the message unless the remainder is a valid generated
+ * payload.
  */
 
 /**
@@ -46,7 +45,8 @@
 const VALUE_START =
   /^\{\s*"handler"\s*:\s*"(?:message|mention|dm)"\s*,\s*(?:"[A-Za-z0-9_]+"\s*:\s*"[^"\\\n]*"\s*,\s*)*"message"\s*:\s*"/;
 
-const TAIL_BOUNDARY = '","user":';
+const TAIL_BOUNDARY =
+  /"\s*,\s*"(?:user|chat|eventId|event_id|attachments|mentions|channel|thread)"\s*:/g;
 
 export function repairDelugeUnescapedMessageBody(raw: string): unknown | undefined {
   const body = raw.trim();
@@ -69,23 +69,36 @@ export function repairDelugeUnescapedMessageBody(raw: string): unknown | undefin
   if (!start) return undefined;
 
   const after = body.slice(start[0].length);
-  const boundary = after.lastIndexOf(TAIL_BOUNDARY);
-  if (boundary <= 0) return undefined;
+  const candidates = [...after.matchAll(TAIL_BOUNDARY)];
+  for (const candidate of candidates.reverse()) {
+    const boundary = candidate.index;
+    if (boundary === undefined || boundary <= 0) continue;
 
-  const rawText = after.slice(0, boundary);
-  const tail = after.slice(boundary + 1); // starts with `,"user":`
-  const repaired =
-    body.slice(0, start[0].length - 1) + // up to (not incl.) the value's opening quote
-    JSON.stringify(rawText) +
-    tail;
-  try {
-    const value: unknown = JSON.parse(repaired);
-    return value && typeof value === "object" && !Array.isArray(value)
-      ? value
-      : undefined;
-  } catch {
-    return undefined;
+    const rawText = after.slice(0, boundary);
+    const tail = after.slice(boundary + 1); // preserve comma + Deluge whitespace
+    const repaired =
+      body.slice(0, start[0].length - 1) + // up to (not incl.) the value's opening quote
+      JSON.stringify(rawText) +
+      tail;
+    try {
+      const value: unknown = JSON.parse(repaired);
+      if (
+        value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        (value as Record<string, unknown>).message === rawText &&
+        typeof (value as Record<string, unknown>).user === "object" &&
+        typeof (value as Record<string, unknown>).chat === "object"
+      ) {
+        return value;
+      }
+    } catch {
+      // A separator-like literal inside message text is not a structural
+      // boundary. Continue left until the reconstructed generated suffix
+      // parses as a complete object carrying the required user/chat maps.
+    }
   }
+  return undefined;
 }
 
 /**
@@ -94,6 +107,12 @@ export function repairDelugeUnescapedMessageBody(raw: string): unknown | undefin
  * identifies the *syntax* of a corrupt payload (unescaped quotes vs. Deluge
  * `a=b` map syntax vs. truncated body) without exposing any user text, so the
  * next unknown corruption documents itself in the default-visible skip line.
+ *
+ * A long body keeps its **tail** as well as its head. The structural boundary
+ * this repair depends on (`","user":` and the generated suffix) lives at the
+ * end, so a head-only fingerprint truncates away the only evidence that
+ * explains why a repair declined — exactly what happened to the 2026-09-11
+ * roundtrip, where 1384 bytes were diagnosed from the first 96.
  */
 export function describeDelugeBodySyntax(raw: string, maxLen = 96): string {
   const masked = raw
@@ -102,5 +121,10 @@ export function describeDelugeBodySyntax(raw: string, maxLen = 96): string {
     .replace(/[^\s⏎]/g, (ch) => (/[A-Za-z0-9]/.test(ch) ? "x" : ch))
     .replace(/x{2,}/g, "x*")
     .replace(/\s+/g, " ");
-  return masked.slice(0, maxLen);
+  if (masked.length <= maxLen) return masked;
+  const ELLIPSIS = "…";
+  // Bias toward the tail: the generated suffix is where the boundary lives.
+  const tailLen = Math.floor((maxLen - ELLIPSIS.length) / 2);
+  const headLen = maxLen - ELLIPSIS.length - tailLen;
+  return masked.slice(0, headLen) + ELLIPSIS + masked.slice(masked.length - tailLen);
 }

--- a/src/load.test.ts
+++ b/src/load.test.ts
@@ -1612,6 +1612,18 @@ describe("Deluge unescaped-message repair over the webhook (#223/#227)", () => {
     expect(warns.filter((l) => l.startsWith("[cliq] inbound skipped:"))).toHaveLength(0);
   });
 
+  it("dispatches the live multiline/entity shape with Deluge separator whitespace", async () => {
+    const { webhook, warns, dispatches } = registrationWithLogs({
+      extra: { dmPolicy: "open" },
+    });
+    const corrupt =
+      '{"handler":"message","handlerSchema":"v2","message":"OPENCLAW_CLIQ_ROUNDTRIP_REQUEST test\nContact email: test@example.invalid\nTelephone: +1 202-555-0100\nQuoted text: "doctor-safe"" , "user" : {"id":"user-123","name":"Alice"}, "chat" : {"id":"chat-1-B","type":"single"}, "eventId" : "evt-live-shape-1"}';
+    const res = await postRaw(webhook, corrupt);
+    expect(res.statusCode).toBe(200);
+    expect(dispatches()).toBe(1);
+    expect(warns.filter((l) => l.startsWith("[cliq] inbound skipped:"))).toHaveLength(0);
+  });
+
   it("still rejects (with the shape fingerprint) what the repair cannot fix", async () => {
     const { webhook, warns } = registrationWithLogs();
     // Distinctive marker word so the assertion proves the *fingerprint*


### PR DESCRIPTION
Closes #225 after a repeat live roundtrip on the merged build.

## Live failure

The consented 2026-09-11 Doctor challenge reached `/cliq/webhook` as an
authenticated 1384-byte POST, but was rejected as `empty_body` before agent
dispatch. The exact multi-line body contained the reserved email, fictional
phone and quoted text from the Doctor challenge; Aura therefore never replied.

The repair recognized only the exact structural boundary `\",\"user\":` after
the unescaped `message` value. Zoho's Deluge `Map.toString()` may vary
insignificant whitespace and map order, so the body can remain structurally
complete while missing that byte-exact marker.

## Fix

- Match whitespace-tolerant separators before known generated fields.
- Try candidates from right to left, accepting only a reconstructed object that
  preserves the complete message and contains object-form `user` and `chat`.
- Keep both head and tail in the content-masked syntax fingerprint, because the
  structural separator is at the end of long bodies.
- Add parser and full webhook-dispatch regressions for the exact
  multiline/entity-like challenge shape.
- Update README, CHANGELOG and the existing durable Deluge learning.

## Verification

- `npx tsc --noEmit`
- focused parser + route tests: 75 passed
- `npm test`: 105 files, 2389 tests passed
- `npm run build`
- `npm run smoke:gateway`: 12/12, real gateway and HTTP ingress

After merge, the linked checkout must be rebuilt/restarted and the same live
Doctor roundtrip repeated before #225 is closed.